### PR TITLE
Fix segfault when app is garbage collected

### DIFF
--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -383,6 +383,7 @@ def qapp():
         app = QApplication([])
         yield app
         app.exit()
+        app.deleteLater()
     else:
         yield app  # pragma: no cover
 


### PR DESCRIPTION
When I was using pytest-qt with a test suite I have, I was getting a segfault after all the tests passed. I realized that the `QApplication` instance in the `qapp` fixture was probably getting garbage collected too early. I just added a `deleteLater` call so the C++ `QApplication` object gets deleted before Python garbage collects the variable. This fixed my test suite at least, and doesn't seem to cause any harm.