### PR TITLE
Add a raising parameter to waitSignal.

### DIFF
--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -327,8 +327,11 @@ class SignalBlocker(object):
         if self.timeout is None and len(self._signals) == 0:
             raise ValueError("No signals or timeout specified.")
         if self.timeout is not None:
-            QtCore.QTimer.singleShot(self.timeout, self._quit_loop_by_timeout)
+            QtCore.QTimer.singleShot(self.timeout, self._loop.quit)
         self._loop.exec_()
+        if not self.signal_triggered and self.raising:
+            raise QtBot.SignalTimeout("Didn't get signal after %sms." %
+                                      self.timeout)
 
     def connect(self, signal):
         """
@@ -346,17 +349,6 @@ class SignalBlocker(object):
         """
         self.signal_triggered = True
         self._loop.quit()
-
-    def _quit_loop_by_timeout(self):
-        """
-        quits the event loop and marks that we finished because of a timeout.
-        """
-        assert not self.signal_triggered
-        self._loop.quit()
-        if self.raising:
-            raise QtBot.SignalTimeout("Didn't get signal after %sms." %
-                                      self.timeout)
-
 
     def __enter__(self):
         return self


### PR DESCRIPTION
I tried to add a `raising` parameter to `waitSignal` (so it'd be easier to notice if a signal wasn't emitted), but now I'm stuck.

When running the tests as-is, I get a segfault:

```
pytestqt/_tests/test_wait_signal.py::test_signal_triggered[wait_function6-2000-500-False-True] FAILED
pytestqt/_tests/test_wait_signal.py::test_signal_triggered[wait_function6-2000-500-False-True] ERROR
pytestqt/_tests/test_wait_signal.py::test_signal_triggered[wait_function7-2000-500-False-True] Fatal Python error: Segmentation fault

Current thread 0x00007f6be5e35700 (most recent call first):
  File "/home/florian/proj/pytest-qt/pytestqt/plugin.py", line 323 in wait
  File "/home/florian/proj/pytest-qt/pytestqt/plugin.py", line 357 in __exit__
  File "/home/florian/proj/pytest-qt/pytestqt/_tests/test_wait_signal.py", line 36 in context_manager_wait
  File "/home/florian/proj/pytest-qt/pytestqt/_tests/test_wait_signal.py", line 68 in test_signal_triggered
  File "/usr/lib/python3.4/site-packages/_pytest/python.py", line 204 in pytest_pyfunc_call
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 394 in execute
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 528 in _docall
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 521 in __call__
  File "/usr/lib/python3.4/site-packages/_pytest/python.py", line 1174 in runtest
  File "/usr/lib/python3.4/site-packages/_pytest/runner.py", line 90 in pytest_runtest_call
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 394 in execute
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 123 in __init__
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 107 in wrapped_call
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 393 in execute
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 528 in _docall
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 521 in __call__
  File "/usr/lib/python3.4/site-packages/_pytest/runner.py", line 137 in <lambda>
  File "/usr/lib/python3.4/site-packages/_pytest/runner.py", line 149 in __init__
  File "/usr/lib/python3.4/site-packages/_pytest/runner.py", line 137 in call_runtest_hook
  File "/usr/lib/python3.4/site-packages/_pytest/runner.py", line 119 in call_and_report
  File "/usr/lib/python3.4/site-packages/_pytest/runner.py", line 75 in runtestprotocol
  File "/usr/lib/python3.4/site-packages/_pytest/runner.py", line 65 in pytest_runtest_protocol
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 394 in execute
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 123 in __init__
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 107 in wrapped_call
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 393 in execute
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 528 in _docall
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 521 in __call__
  File "/usr/lib/python3.4/site-packages/_pytest/main.py", line 142 in pytest_runtestloop
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 394 in execute
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 528 in _docall
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 521 in __call__
  File "/usr/lib/python3.4/site-packages/_pytest/main.py", line 122 in _main
  File "/usr/lib/python3.4/site-packages/_pytest/main.py", line 84 in wrap_session
  File "/usr/lib/python3.4/site-packages/_pytest/main.py", line 116 in pytest_cmdline_main
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 394 in execute
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 528 in _docall
  File "/usr/lib/python3.4/site-packages/_pytest/core.py", line 521 in __call__
  File "/usr/lib/python3.4/site-packages/_pytest/config.py", line 41 in main
  File "/usr/lib/python3.4/site-packages/py/test.py", line 4 in <module>
  File "/usr/lib64/python3.4/runpy.py", line 85 in _run_code
  File "/usr/lib64/python3.4/runpy.py", line 170 in _run_module_as_main
```

When removing the last testcase `(context_manager_wait, 2000, 500, False, True),` I get:

```
================================= ERRORS =================================
 ERROR at teardown of test_signal_triggered[wait_function6-2000-500-False-True] 

self = <_pytest.runner.SetupState object at 0x7f559627f1d0>
colitem = <Function 'test_signal_triggered[wait_function6-2000-500-False-True]'>

    def _callfinalizers(self, colitem):
        finalizers = self._finalizers.pop(colitem, None)
        exc = None
        while finalizers:
            fin = finalizers.pop()
            try:
>               fin()

/usr/lib/python3.4/site-packages/_pytest/runner.py:356: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.4/site-packages/_pytest/python.py:1856: in finish
    func()
/usr/lib/python3.4/site-packages/_pytest/python.py:1814: in teardown
    next()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

qapp = None
request = <SubRequest 'qtbot' for <Function 'test_signal_triggered[wait_function6-2000-500-False-True]'>>

    @pytest.yield_fixture
    def qtbot(qapp, request):
        """
        Fixture used to create a QtBot instance for using during testing.
    
        Make sure to call addWidget for each top-level widget you create to ensure
        that they are properly closed after the test ends.
        """
        result = QtBot()
        no_capture = request.node.get_marker('qt_no_exception_capture') or \
                     request.config.getini('qt_no_exception_capture')
        if no_capture:
            yield result  # pragma: no cover
        else:
            with capture_exceptions() as exceptions:
                yield result
            if exceptions:
>               pytest.fail(format_captured_exceptions(exceptions))
E               Failed: Qt exceptions in virtual methods:
E               ________________________________________________________________________________
E                 File "/home/florian/proj/pytest-qt/pytestqt/plugin.py", line 350, in _quit_loop_by_timeout
E                   self.timeout)
E               
E               SignalTimeout: Didn't get signal after 500ms.
E               ________________________________________________________________________________

pytestqt/plugin.py:430: Failed
-------------------------- Captured stderr call --------------------------
Traceback (most recent call last):
  File "/home/florian/proj/pytest-qt/pytestqt/plugin.py", line 350, in _quit_loop_by_timeout
    self.timeout)
pytestqt.plugin.SignalTimeout: Didn't get signal after 500ms.
================================ FAILURES ================================
_______ test_signal_triggered[wait_function6-2000-500-False-True] ________

qtbot = <pytestqt.plugin.QtBot object at 0x7f5595c48ba8>
wait_function = <function explicit_wait at 0x7f55962b2950>
emit_delay = 2000, timeout = 500, expected_signal_triggered = False
raising = True

    @pytest.mark.parametrize(
        ('wait_function', 'emit_delay', 'timeout', 'expected_signal_triggered',
         'raising'),
        [
            (explicit_wait, 500, 2000, True, False),
            (explicit_wait, 500, None, True, False),
            (context_manager_wait, 500, 2000, True, False),
            (context_manager_wait, 500, None, True, False),
            (explicit_wait, 2000, 500, False, False),
            (context_manager_wait, 2000, 500, False, False),
            (explicit_wait, 2000, 500, False, True),
            #(context_manager_wait, 2000, 500, False, True),
        ]
    )
    def test_signal_triggered(qtbot, wait_function, emit_delay, timeout,
                              expected_signal_triggered, raising):
        """
        Testing for a signal in different conditions, ensuring we are obtaining
        the expected results.
        """
        signaller = Signaller()
        QtCore.QTimer.singleShot(emit_delay, signaller.signal.emit)
    
        # block signal until either signal is emitted or timeout is reached
        start_time = time.time()
        if raising:
            with pytest.raises(qtbot.SignalTimeout):
                blocker = wait_function(qtbot, signaller.signal, timeout,
>                                       raising=True)
E               Failed: DID NOT RAISE

pytestqt/_tests/test_wait_signal.py:68: Failed
-------------------------- Captured stderr call --------------------------
Traceback (most recent call last):
  File "/home/florian/proj/pytest-qt/pytestqt/plugin.py", line 350, in _quit_loop_by_timeout
    self.timeout)
pytestqt.plugin.SignalTimeout: Didn't get signal after 500ms.
```

So it seems the exception is handled by `capture_exceptions`, and I can't see a good way to avoid that.