### PR TITLE
[WIP] Add waitSignals.

### DIFF
--- a/pytestqt/_tests/test_wait_signal.py
+++ b/pytestqt/_tests/test_wait_signal.py
@@ -25,10 +25,7 @@ def explicit_wait(qtbot, signal, timeout, multiple):
     """
     func = qtbot.waitSignals if multiple else qtbot.waitSignal
     blocker = func(signal, timeout)
-    if multiple:
-        assert not blocker.signals_triggered
-    else:
-        assert not blocker.signal_triggered
+    assert not blocker.signal_triggered
     blocker.wait()
     return blocker
 
@@ -87,7 +84,7 @@ def test_signal_triggered(qtbot, wait_function, emit_delay, timeout,
 
 @pytest.mark.parametrize(
     ('wait_function', 'emit_delay_1', 'emit_delay_2', 'timeout',
-     'expected_signals_triggered'),
+     'expected_signal_triggered'),
     [
         (explicit_wait, 500, 600, 2000, True),
         (explicit_wait, 500, 600, None, True),
@@ -103,7 +100,7 @@ def test_signal_triggered(qtbot, wait_function, emit_delay, timeout,
 )
 def test_signal_triggered_multiple(qtbot, wait_function, emit_delay_1,
                                    emit_delay_2, timeout,
-                                   expected_signals_triggered):
+                                   expected_signal_triggered):
     """
     Testing for a signal in different conditions, ensuring we are obtaining
     the expected results.
@@ -129,7 +126,7 @@ def test_signal_triggered_multiple(qtbot, wait_function, emit_delay_1,
     assert not blocker._loop.isRunning()
 
     # ensure that either signal was triggered or timeout occurred
-    assert blocker.signals_triggered == expected_signals_triggered
+    assert blocker.signal_triggered == expected_signal_triggered
 
     # Check that we exited by the earliest parameter; timeout = None means
     # wait forever, so ensure we waited at most 4 times emit-delay
@@ -160,4 +157,4 @@ def test_explicit_emit_multiple(qtbot):
         signaller.signal.emit()
         signaller.signal_2.emit()
 
-    assert waiting.signals_triggered
+    assert waiting.signal_triggered

--- a/pytestqt/_tests/test_wait_signal.py
+++ b/pytestqt/_tests/test_wait_signal.py
@@ -7,6 +7,7 @@ from pytestqt.qt_compat import QtCore, Signal
 class Signaller(QtCore.QObject):
 
     signal = Signal()
+    signal_2 = Signal()
 
 
 def test_signal_blocker_exception(qtbot):
@@ -18,21 +19,26 @@ def test_signal_blocker_exception(qtbot):
         qtbot.waitSignal(None, None).wait()
 
 
-def explicit_wait(qtbot, signal, timeout):
+def explicit_wait(qtbot, signal, timeout, multiple):
     """
     Explicit wait for the signal using blocker API.
     """
-    blocker = qtbot.waitSignal(signal, timeout)
-    assert not blocker.signal_triggered
+    func = qtbot.waitSignals if multiple else qtbot.waitSignal
+    blocker = func(signal, timeout)
+    if multiple:
+        assert not blocker.signals_triggered
+    else:
+        assert not blocker.signal_triggered
     blocker.wait()
     return blocker
 
 
-def context_manager_wait(qtbot, signal, timeout):
+def context_manager_wait(qtbot, signal, timeout, multiple):
     """
     Waiting for signal using context manager API.
     """
-    with qtbot.waitSignal(signal, timeout) as blocker:
+    func = qtbot.waitSignals if multiple else qtbot.waitSignal
+    with func(signal, timeout) as blocker:
         pass
     return blocker
 
@@ -55,6 +61,7 @@ def test_signal_triggered(qtbot, wait_function, emit_delay, timeout,
     the expected results.
     """
     signaller = Signaller()
+
     timer = QtCore.QTimer()
     timer.setSingleShot(True)
     timer.timeout.connect(signaller.signal.emit)
@@ -62,7 +69,7 @@ def test_signal_triggered(qtbot, wait_function, emit_delay, timeout,
 
     # block signal until either signal is emitted or timeout is reached
     start_time = time.time()
-    blocker = wait_function(qtbot, signaller.signal, timeout)
+    blocker = wait_function(qtbot, signaller.signal, timeout, multiple=False)
 
     # Check that event loop exited.
     assert not blocker._loop.isRunning()
@@ -78,6 +85,60 @@ def test_signal_triggered(qtbot, wait_function, emit_delay, timeout,
     assert time.time() - start_time < (max_wait_ms / 1000.0)
 
 
+@pytest.mark.parametrize(
+    ('wait_function', 'emit_delay_1', 'emit_delay_2', 'timeout',
+     'expected_signals_triggered'),
+    [
+        (explicit_wait, 500, 600, 2000, True),
+        (explicit_wait, 500, 600, None, True),
+        (context_manager_wait, 500, 600, 2000, True),
+        (context_manager_wait, 500, 600, None, True),
+        (explicit_wait, 2000, 2000, 500, False),
+        (explicit_wait, 500, 2000, 1000, False),
+        (explicit_wait, 2000, 500, 1000, False),
+        (context_manager_wait, 2000, 2000, 500, False),
+        (context_manager_wait, 500, 2000, 1000, False),
+        (context_manager_wait, 2000, 500, 1000, False),
+    ]
+)
+def test_signal_triggered_multiple(qtbot, wait_function, emit_delay_1,
+                                   emit_delay_2, timeout,
+                                   expected_signals_triggered):
+    """
+    Testing for a signal in different conditions, ensuring we are obtaining
+    the expected results.
+    """
+    signaller = Signaller()
+
+    timer = QtCore.QTimer()
+    timer.setSingleShot(True)
+    timer.timeout.connect(signaller.signal.emit)
+    timer.start(emit_delay_1)
+
+    timer2 = QtCore.QTimer()
+    timer2.setSingleShot(True)
+    timer2.timeout.connect(signaller.signal_2.emit)
+    timer2.start(emit_delay_2)
+
+    # block signal until either signal is emitted or timeout is reached
+    start_time = time.time()
+    blocker = wait_function(qtbot, [signaller.signal, signaller.signal_2],
+                            timeout, multiple=True)
+
+    # Check that event loop exited.
+    assert not blocker._loop.isRunning()
+
+    # ensure that either signal was triggered or timeout occurred
+    assert blocker.signals_triggered == expected_signals_triggered
+
+    # Check that we exited by the earliest parameter; timeout = None means
+    # wait forever, so ensure we waited at most 4 times emit-delay
+    if timeout is None:
+        timeout = max(emit_delay_1, emit_delay_2) * 4
+    max_wait_ms = max(emit_delay_1, emit_delay_2, timeout)
+    assert time.time() - start_time < (max_wait_ms / 1000.0)
+
+
 def test_explicit_emit(qtbot):
     """
     Make sure an explicit emit() inside a waitSignal block works.
@@ -87,3 +148,16 @@ def test_explicit_emit(qtbot):
         signaller.signal.emit()
 
     assert waiting.signal_triggered
+
+
+def test_explicit_emit_multiple(qtbot):
+    """
+    Make sure an explicit emit() inside a waitSignal block works.
+    """
+    signaller = Signaller()
+    with qtbot.waitSignals([signaller.signal, signaller.signal_2],
+                           timeout=5000) as waiting:
+        signaller.signal.emit()
+        signaller.signal_2.emit()
+
+    assert waiting.signals_triggered


### PR DESCRIPTION
After I was stuck with the other PR I tried adding something else I've been missing: The possibility to wait for *multiple* signals (until all have been emitted).

Here I also get a segfault:

```
pytestqt/_tests/test_wait_signal.py::test_signal_triggered[wait_function5-2000-500-False] PASSED
pytestqt/_tests/test_wait_signal.py::test_signal_triggered_multiple[wait_function0-5000-10000-20000-True] Fatal Python error: Segmentation fault

Current thread 0x00007f827e961700 (most recent call first):
  File "/home/florian/proj/pytest-qt/pytestqt/plugin.py", line 418 in wait
  File "/home/florian/proj/pytest-qt/pytestqt/_tests/test_wait_signal.py", line 32 in explicit_wait
  File "/home/florian/proj/pytest-qt/pytestqt/_tests/test_wait_signal.py", line 112 in test_signal_triggered_multiple
[...]
```

```
#0  0x0000555555d824a0 in ?? ()
#1  0x00007ffff3062921 in pyqtBoundSignal_emit (self=0x7ffff3371878, args=0x7ffff7fb8048) at ../qpy/QtCore/qpycore_pyqtboundsignal.cpp:633
#2  0x00007ffff79a9528 in PyObject_Call (func=func@entry=0x7fffe8f3fb08, arg=arg@entry=0x7ffff7fb8048, kw=<optimized out>) at Objects/abstract.c:2040
#3  0x00007ffff7a56867 in PyEval_CallObjectWithKeywords (func=0x7fffe8f3fb08, arg=0x7ffff7fb8048, kw=<optimized out>) at Python/ceval.c:4114
#4  0x00007ffff304e610 in PyQtSlot::call (this=0x555555e4b2e0, callable=0x7fffe8f3fb08, args=0x7ffff7fb8048) at ../qpy/QtCore/qpycore_pyqtslot.cpp:222
#5  0x00007ffff304e390 in PyQtSlot::invoke (this=0x555555e4b2e0, qargs=0x7fffffff73f0, self=0x0, result=0x0, no_receiver_check=false) at ../qpy/QtCore/qpycore_pyqtslot.cpp:147
#6  0x00007ffff304e0b6 in PyQtSlot::invoke (this=0x555555e4b2e0, qargs=0x7fffffff73f0, no_receiver_check=false) at ../qpy/QtCore/qpycore_pyqtslot.cpp:76
#7  0x00007ffff304fa2d in PyQtSlotProxy::unislot (this=0x555555e6a330, qargs=0x7fffffff73f0) at ../qpy/QtCore/qpycore_pyqtslotproxy.cpp:205
#8  0x00007ffff304f981 in PyQtSlotProxy::qt_metacall (this=0x555555e6a330, _c=QMetaObject::InvokeMetaMethod, _id=0, _a=0x7fffffff73f0) at ../qpy/QtCore/qpycore_pyqtslotproxy.cpp:170
#9  0x00007ffff2bbccea in QMetaObject::activate (sender=sender@entry=0x555555e50eb0, signalOffset=<optimized out>, local_signal_index=local_signal_index@entry=0, argv=argv@entry=0x0) at kernel/qobject.cpp:3733
#10 0x00007ffff2bbd257 in QMetaObject::activate (sender=sender@entry=0x555555e50eb0, m=m@entry=0x7ffff2dd90c0 <QSingleShotTimer::staticMetaObject>, local_signal_index=local_signal_index@entry=0, argv=argv@entry=0x0)
    at kernel/qobject.cpp:3583
#11 0x00007ffff2bca71b in timeout (this=0x555555e50eb0) at .moc/qtimer.moc:123
#12 QSingleShotTimer::timerEvent (this=0x555555e50eb0) at kernel/qtimer.cpp:318
#13 0x00007ffff2bbd8e3 in QObject::event (this=0x555555e50eb0, e=<optimized out>) at kernel/qobject.cpp:1268
#14 0x00007fffe9d3f646 in QApplicationPrivate::notify_helper (this=this@entry=0x555555d537f0, receiver=receiver@entry=0x555555e50eb0, e=e@entry=0x7fffffff7780) at kernel/qapplication.cpp:3717
#15 0x00007fffe9d44521 in QApplication::notify (this=0x555555d3a4c0, receiver=0x555555e50eb0, e=0x7fffffff7780) at kernel/qapplication.cpp:3161
#16 0x00007fffe92d9f18 in sipQApplication::notify (this=0x555555d3a4c0, a0=0x555555e50eb0, a1=0x7fffffff7780) at sipQtWidgetsQApplication.cpp:349
#17 0x00007ffff2b8c9fb in QCoreApplication::notifyInternal (this=0x555555d3a4c0, receiver=0x555555e50eb0, event=event@entry=0x7fffffff7780) at kernel/qcoreapplication.cpp:963
#18 0x00007ffff2be4aad in sendEvent (event=0x7fffffff7780, receiver=<optimized out>) at ../../include/QtCore/../../src/corelib/kernel/qcoreapplication.h:224
#19 QTimerInfoList::activateTimers (this=0x555555d79830) at kernel/qtimerinfo_unix.cpp:637
#20 0x00007ffff2be4ef1 in timerSourceDispatch (source=<optimized out>) at kernel/qeventdispatcher_glib.cpp:177
#21 0x00007ffff16b39fd in g_main_context_dispatch () from /usr/lib/libglib-2.0.so.0
#22 0x00007ffff16b3ce0 in ?? () from /usr/lib/libglib-2.0.so.0
#23 0x00007ffff16b3d8c in g_main_context_iteration () from /usr/lib/libglib-2.0.so.0
#24 0x00007ffff2be5bcc in QEventDispatcherGlib::processEvents (this=0x555555d79550, flags=...) at kernel/qeventdispatcher_glib.cpp:418
#25 0x00007fffe87eb94c in QPAEventDispatcherGlib::processEvents (this=<optimized out>, flags=...) at eventdispatchers/qeventdispatcher_glib.cpp:115
#26 0x00007ffff2b8a3f2 in QEventLoop::exec (this=0x555555b577a0, flags=...) at kernel/qeventloop.cpp:204
[...]
```