### PR TITLE
Install debugging symbols on Travis

### DIFF
--- a/install-qt.py
+++ b/install-qt.py
@@ -4,23 +4,24 @@ and python version. Meant to be used in travis-ci.
 '''
 import os
 import sys
+import subprocess
 
-def run(cmd):
-    print(cmd)
-    r = os.system(cmd)
-    if r != 0:
-        sys.exit('command %s failed with status %s' % (cmd, r))
+
+def install(packages):
+    print('Installing %s...' % ', '.join(packages))
+    subprocess.check_call(['sudo', 'apt-get', 'install', '-qq'] + packages)
 
 py3k = sys.version_info[0] == 3
 if os.environ['PYTEST_QT_API'] in ('pyqt4', 'pyqt5'):
     pyqt_ver = os.environ['PYTEST_QT_API'][-1]
     if py3k:
-        run('sudo apt-get install -qq python3-pyqt%s{,-dbg}' % pyqt_ver)
+        pkg = 'python3-pyqt%s' % pyqt_ver
     else:
-        run('sudo apt-get install -qq python-qt%s{,-dbg}' % pyqt_ver)
+        pkg = 'python-qt%s' % pyqt_ver
+    install([pkg, pkg + '-dbg'])
 else:
     if py3k:
-        run('sudo apt-get install -qq python3-pyside{,-dbg}')
+        pkg = 'python3-pyside'
     else:
-        run('sudo apt-get install -qq python-pyside{,-dbg}')
-
+        pkg = 'python-pyside'
+    install([pkg, pkg + '-dbg'])

--- a/install-qt.py
+++ b/install-qt.py
@@ -15,12 +15,12 @@ py3k = sys.version_info[0] == 3
 if os.environ['PYTEST_QT_API'] in ('pyqt4', 'pyqt5'):
     pyqt_ver = os.environ['PYTEST_QT_API'][-1]
     if py3k:
-        run('sudo apt-get install -qq python3-pyqt%s' % pyqt_ver)
+        run('sudo apt-get install -qq python3-pyqt%s{,-dbg}' % pyqt_ver)
     else:
-        run('sudo apt-get install -qq python-qt%s' % pyqt_ver)
+        run('sudo apt-get install -qq python-qt%s{,-dbg}' % pyqt_ver)
 else:
     if py3k:
-        run('sudo apt-get install -qq python3-pyside')
+        run('sudo apt-get install -qq python3-pyside{,-dbg}')
     else:
         run('sudo apt-get install -qq python-pyside')
 

--- a/install-qt.py
+++ b/install-qt.py
@@ -22,5 +22,5 @@ else:
     if py3k:
         run('sudo apt-get install -qq python3-pyside{,-dbg}')
     else:
-        run('sudo apt-get install -qq python-pyside')
+        run('sudo apt-get install -qq python-pyside{,-dbg}')
 

--- a/install-qt.py
+++ b/install-qt.py
@@ -24,4 +24,4 @@ else:
         pkg = 'python3-pyside'
     else:
         pkg = 'python-pyside'
-    install([pkg, pkg + '-dbg'])
+    install([pkg])


### PR DESCRIPTION
This hopefully gives us better backtraces...

I'm not sure if all those exist - e.g. `python-pyside-dbg` will probably not be available - but let's try, and if one is missing I'll remove it.