### PR TITLE
Fix building of docs on python3.

### DIFF
--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -98,8 +98,10 @@ else:  # pragma: no cover
         def __getattr__(cls, name):
             if name in ('__file__', '__path__'):
                 return '/dev/null'
-            elif name == '__name__':
+            elif name in ('__name__', '__qualname__'):
                 return name
+            elif name == '__annotations__':
+                return {}
             else:
                 return Mock()
     


### PR DESCRIPTION
The Mock object which is used when building docs returned another Mock for all
attributes except some special attributes.

In Python 3, `__qualname__` (which must be a string) and `__annotations__`
(which must be a dict) got added, which caused building docs to fail.

Fixes #49.