### PR TITLE
Bump pytest version for Travis to 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ matrix:
 env:
  - PYTEST_VERSION=2.6.4 PYTEST_QT_API=pyqt4
  - PYTEST_VERSION=2.6.4 PYTEST_QT_API=pyside
- - PYTEST_VERSION=2.7.0 PYTEST_QT_API=pyqt4
- - PYTEST_VERSION=2.7.0 PYTEST_QT_API=pyside
- - PYTEST_VERSION=2.7.0 PYTEST_QT_API=pyqt5
+ - PYTEST_VERSION=2.7.1 PYTEST_QT_API=pyqt4
+ - PYTEST_VERSION=2.7.1 PYTEST_QT_API=pyside
+ - PYTEST_VERSION=2.7.1 PYTEST_QT_API=pyqt5
 
 install:
  - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa


### PR DESCRIPTION
Upstream changelog:

fix issue731: do not get confused by the braces which may be present and unbalanced in an object’s repr while collapsing False explanations. Thanks Carl Meyer for the report and test case.
fix issue553: properly handling inspect.getsourcelines failures in FixtureLookupError which would lead to to an internal error, obfuscating the original problem. Thanks talljosh for initial diagnose/patch and Bruno Oliveira for final patch.
fix issue660: properly report scope-mismatch-access errors independently from ordering of fixture arguments. Also avoid the pytest internal traceback which does not provide information to the user. Thanks Holger Krekel.
streamlined and documented release process. Also all versions (in setup.py and documentation generation) are now read from _pytest/__init__.py. Thanks Holger Krekel.
fixed docs to remove the notion that yield-fixtures are experimental. They are here to stay :) Thanks Bruno Oliveira.
Support building wheels by using environment markers for the requirements. Thanks Ionel Maries Cristian.
fixed regression to 2.6.4 which surfaced e.g. in lost stdout capture printing when tests raised SystemExit. Thanks Holger Krekel.
reintroduced _pytest fixture of the pytester plugin which is used at least by pytest-xdist.