### PR TITLE
Disconnect SignalBlocker after exiting loop.

### DIFF
--- a/pytestqt/_tests/test_wait_signal.py
+++ b/pytestqt/_tests/test_wait_signal.py
@@ -217,9 +217,8 @@ def stop_watch():
     return StopWatch()
 
 
-@pytest.mark.parametrize('multiple, raising',
-                         [(True, True), (True, False), (False, True),
-                          (False, False)])
+@pytest.mark.parametrize('multiple', [True, False])
+@pytest.mark.parametrize('raising', [True, False])
 def test_wait_signals_handles_exceptions(qtbot, multiple, raising):
     """
     Make sure waitSignal handles exceptions correctly.
@@ -241,8 +240,8 @@ def test_wait_signals_handles_exceptions(qtbot, multiple, raising):
             raise TestException
 
 
-@pytest.mark.parametrize('multiple, do_timeout',
-                         [(True, False), (True, True), (False, False), (False, True)])
+@pytest.mark.parametrize('multiple', [True, False])
+@pytest.mark.parametrize('do_timeout', [True, False])
 def test_wait_twice(qtbot, single_shot, multiple, do_timeout):
     """
     https://github.com/pytest-dev/pytest-qt/issues/69

--- a/pytestqt/_tests/test_wait_signal.py
+++ b/pytestqt/_tests/test_wait_signal.py
@@ -239,3 +239,30 @@ def test_wait_signals_handles_exceptions(qtbot, multiple, raising):
     with pytest.raises(TestException):
         with func(arg, timeout=10, raising=raising):
             raise TestException
+
+
+@pytest.mark.parametrize('multiple, do_timeout',
+                         [(True, False), (True, True), (False, False), (False, True)])
+def test_wait_twice(qtbot, single_shot, multiple, do_timeout):
+    """
+    https://github.com/pytest-dev/pytest-qt/issues/69
+    """
+    signaller = Signaller()
+
+    if multiple:
+        func = qtbot.waitSignals
+        arg = [signaller.signal]
+    else:
+        func = qtbot.waitSignal
+        arg = signaller.signal
+
+    if do_timeout:
+        with func(arg, timeout=100):
+            single_shot(signaller.signal, 200)
+        with func(arg, timeout=100):
+            single_shot(signaller.signal, 200)
+    else:
+        with func(arg):
+            signaller.signal.emit()
+        with func(arg):
+            signaller.signal.emit()

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -355,9 +355,11 @@ class _AbstractSignalBlocker(object):
         self.timeout = timeout
         self.signal_triggered = False
         self.raising = raising
-        self._timer = QtCore.QTimer()
-        self._timer.setSingleShot(True)
-        if timeout is not None:
+        if timeout is None:
+            self._timer = None
+        else:
+            self._timer = QtCore.QTimer()
+            self._timer.setSingleShot(True)
             self._timer.setInterval(timeout)
 
     def wait(self):
@@ -371,7 +373,7 @@ class _AbstractSignalBlocker(object):
             return
         if self.timeout is None and not self._signals:
             raise ValueError("No signals or timeout specified.")
-        if self.timeout is not None:
+        if self._timer is not None:
             self._timer.timeout.connect(self._quit_loop_by_timeout)
             self._timer.start()
         self._loop.exec_()
@@ -384,7 +386,7 @@ class _AbstractSignalBlocker(object):
         self._cleanup()
 
     def _cleanup(self):
-        if self.timeout is not None:
+        if self._timer is not None:
             try:
                 self._timer.timeout.disconnect(self._quit_loop_by_timeout)
             except (TypeError, RuntimeError):

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -377,13 +377,13 @@ class _AbstractSignalBlocker(object):
             self._timer.timeout.connect(self._quit_loop_by_timeout)
             self._timer.start()
         self._loop.exec_()
-        self._cleanup()
         if not self.signal_triggered and self.raising:
             raise SignalTimeoutError("Didn't get signal after %sms." %
                                       self.timeout)
 
     def _quit_loop_by_timeout(self):
         self._loop.quit()
+        self._cleanup()
 
     def _cleanup(self):
         if self._timer is not None:
@@ -445,6 +445,7 @@ class SignalBlocker(_AbstractSignalBlocker):
         """
         self.signal_triggered = True
         self._loop.quit()
+        self._cleanup()
 
     def _cleanup(self):
         super(SignalBlocker, self)._cleanup()

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -377,13 +377,13 @@ class _AbstractSignalBlocker(object):
             self._timer.timeout.connect(self._quit_loop_by_timeout)
             self._timer.start()
         self._loop.exec_()
+        self._cleanup()
         if not self.signal_triggered and self.raising:
             raise SignalTimeoutError("Didn't get signal after %sms." %
                                       self.timeout)
 
     def _quit_loop_by_timeout(self):
         self._loop.quit()
-        self._cleanup()
 
     def _cleanup(self):
         if self._timer is not None:
@@ -445,7 +445,6 @@ class SignalBlocker(_AbstractSignalBlocker):
         """
         self.signal_triggered = True
         self._loop.quit()
-        self._cleanup()
 
     def _cleanup(self):
         super(SignalBlocker, self)._cleanup()


### PR DESCRIPTION
Otherwise, a second signal emission will still call the functions of the
already garbage-collected SignalBlocker with PyQt5 < 5.3.

The signals could already be disconnected, so the TypeError (older PyQt
versions) or RuntimeError (newer PyQt versions) which is raised in that case is
ignored.

Fixes #69.