### PR TITLE
Add appveyor install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - Reduced verbosity when exceptions are captured in virtual methods
   (#77, thanks @The-Compiler).
 
+- Internal refactoring in `waitSignal` and `waitSignals` to use a manual
+  busy loop instead of relying on `QEventLoop` and `QTimer`; depending
+  on the order objects are destroyed in tests the previous implementation
+  could leave dangling signal connections which could cause a crash (noticed
+  this on Windows with PySide and PyQt5). Should not affect tests,
+  but if users notice any behavior change between this version and `1.5.1`
+  please make sure to report it (#80, #79, thanks @The-Compiler for support).
+
 - `QApplication.processEvents()` is now called before and after other fixtures
   and teardown hooks, to better try to avoid non-processed events from leaking 
   from one test to the next. (#67, thanks @The-Compiler). 

--- a/README.rst
+++ b/README.rst
@@ -45,12 +45,15 @@ This allows you to test and make sure your view layer is behaving the way you ex
 .. |docs| image:: https://readthedocs.org/projects/pytest-qt/badge/?version=latest
   :target: https://pytest-qt.readthedocs.org
 
+.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/9s5jr17hxcxeo6yx/branch/master?svg=true
+  :target: https://ci.appveyor.com/project/nicoddemus/pytest-qt
+
 .. pypip.in seems to be offline
   .. |python| image:: https://pypip.in/py_versions/pytest-qt/badge.png
   :target: https://pypi.python.org/pypi/pytest-qt/
   :alt: Supported Python versions
 
-|version| |downloads| |ci| |coverage| |docs|
+|version| |downloads| |ci| |appveyor| |coverage| |docs|
 
 Requirements
 ============

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,20 +15,10 @@ environment:
       PYTHON_ARCH: "32"
       TESTENV: "py27"
 
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
-      PYTHON_ARCH: "32"
-      TESTENV: "py33"
-
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "32"
       TESTENV: "py34"
-
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "32"
-      TESTENV: "py26"
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,64 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+
+  matrix:
+
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x" # currently 2.7.9
+      PYTHON_ARCH: "32"
+      TESTENV: "py27"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_ARCH: "32"
+      TESTENV: "py33"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+      PYTHON_ARCH: "32"
+      TESTENV: "py34"
+
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+      TESTENV: "py26"
+
+
+install:
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Install the build dependencies of the project. If some dependencies contain
+  # compiled extensions and are not provided as pre-built wheel packages,
+  # pip will build them from source using the MSVC compiler matching the
+  # target Python version and architecture
+  - "%CMD_IN_ENV% pip install tox"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  # Build the compiled extension and run the project tests
+  - "%CMD_IN_ENV% tox -e %TESTENV%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,16 @@ environment:
       PYTHON_ARCH: "32"
       TESTENV: "py34"
 
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.x" # currently 3.3.5
+      PYTHON_ARCH: "32"
+      TESTENV: "py33"
+
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+      TESTENV: "py26"
+
 
 install:
   - ECHO "Filesystem root:"

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,180 @@
+# Sample script to install Python and pip under Windows
+# Authors: Olivier Grisel, Jonathan Helmus and Kyle Kastner
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+$BASE_URL = "https://www.python.org/ftp/python/"
+$GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+$GET_PIP_PATH = "C:\get-pip.py"
+
+
+function DownloadPython ($python_version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    $filename = "python-" + $python_version + $platform_suffix + ".msi"
+    $url = $BASE_URL + $python_version + "/" + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+
+function InstallPython ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = ""
+    } else {
+        $platform_suffix = ".amd64"
+    }
+    $msipath = DownloadPython $python_version $platform_suffix
+    Write-Host "Installing" $msipath "to" $python_home
+    $install_log = $python_home + ".log"
+    $install_args = "/qn /log $install_log /i $msipath TARGETDIR=$python_home"
+    $uninstall_args = "/qn /x $msipath"
+    RunCommand "msiexec.exe" $install_args
+    if (-not(Test-Path $python_home)) {
+        Write-Host "Python seems to be installed else-where, reinstalling."
+        RunCommand "msiexec.exe" $uninstall_args
+        RunCommand "msiexec.exe" $install_args
+    }
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+function RunCommand ($command, $command_args) {
+    Write-Host $command $command_args
+    Start-Process -FilePath $command -ArgumentList $command_args -Wait -Passthru
+}
+
+
+function InstallPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $python_path = $python_home + "\python.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $webclient = New-Object System.Net.WebClient
+        $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
+        Write-Host "Executing:" $python_path $GET_PIP_PATH
+        Start-Process -FilePath "$python_path" -ArgumentList "$GET_PIP_PATH" -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+
+function DownloadMiniconda ($python_version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    if ($python_version -eq "3.4") {
+        $filename = "Miniconda3-3.5.5-Windows-" + $platform_suffix + ".exe"
+    } else {
+        $filename = "Miniconda-3.5.5-Windows-" + $platform_suffix + ".exe"
+    }
+    $url = $MINICONDA_URL + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $install_log = $python_home + ".log"
+    $args = "/S /D=$python_home"
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallMinicondaPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $args = "install --yes pip"
+        Write-Host $conda_path $args
+        Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+function main () {
+    InstallPython $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    InstallPip $env:PYTHON
+}
+
+main

--- a/appveyor/run_with_env.cmd
+++ b/appveyor/run_with_env.cmd
@@ -1,0 +1,47 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.0"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%PYTHON_ARCH%"=="64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/pytestqt/_tests/test_wait_signal.py
+++ b/pytestqt/_tests/test_wait_signal.py
@@ -69,9 +69,9 @@ def build_signal_tests_variants(params):
      'wait_function', 'raising'),
     build_signal_tests_variants([
         # delay, timeout, expected_signal_triggered
-        (100, None, True),
-        (100, 200, True),
-        (200, 100, False),
+        (200, None, True),
+        (200, 400, True),
+        (400, 200, False),
     ])
 )
 def test_signal_triggered(qtbot, timer, stop_watch, wait_function, delay,
@@ -89,7 +89,6 @@ def test_signal_triggered(qtbot, timer, stop_watch, wait_function, delay,
     blocker = wait_function(qtbot, signaller.signal, timeout, raising=raising,
                             should_raise=should_raise, multiple=False)
 
-    timer.shutdown()
     # ensure that either signal was triggered or timeout occurred
     assert blocker.signal_triggered == expected_signal_triggered
 
@@ -101,13 +100,13 @@ def test_signal_triggered(qtbot, timer, stop_watch, wait_function, delay,
      'wait_function', 'raising'),
     build_signal_tests_variants([
         # delay1, delay2, timeout, expected_signal_triggered
-        (100, 150, 200, True),
-        (150, 100, 200, True),
-        (100, 150, None, True),
-        (200, 200, 100, False),
-        (100, 200, 150, False),
-        (200, 100, 100, False),
-        (100, 500, 200, False),
+        (200, 300, 400, True),
+        (300, 200, 400, True),
+        (200, 300, None, True),
+        (400, 400, 200, False),
+        (200, 400, 300, False),
+        (400, 200, 200, False),
+        (200, 1000, 400, False),
     ])
 )
 def test_signal_triggered_multiple(qtbot, timer, stop_watch, wait_function,
@@ -232,9 +231,10 @@ def stop_watch():
             delays used to trigger a signal has passed.
             """
             if timeout is None:
-                timeout = max(delays) * 1.25  # 25% tolerance
+                timeout = max(delays) * 1.30  # 30% tolerance
             max_wait_ms = max(delays + (timeout,))
-            assert time.time() - self._start_time < (max_wait_ms / 1000.0)
+            elapsed_ms = (time.time() - self._start_time) * 1000.0
+            assert elapsed_ms < max_wait_ms
 
     return StopWatch()
 

--- a/pytestqt/_tests/test_wait_signal.py
+++ b/pytestqt/_tests/test_wait_signal.py
@@ -93,9 +93,6 @@ def test_signal_triggered(qtbot, single_shot, stop_watch, wait_function, delay,
     blocker = wait_function(qtbot, signaller.signal, timeout, raising=raising,
                             should_raise=should_raise, multiple=False)
 
-    # Check that event loop exited.
-    assert not blocker._loop.isRunning()
-
     # ensure that either signal was triggered or timeout occurred
     assert blocker.signal_triggered == expected_signal_triggered
 
@@ -124,11 +121,10 @@ def test_signal_triggered_multiple(qtbot, single_shot, stop_watch, wait_function
     the expected results.
     """
     import sys
-    if delay_1 == 200 and delay_2 == 100 and timeout == 100 \
-            and not expected_signal_triggered \
-            and sys.platform.startswith('win32'):
-        pytest.skip('crashing on windows (#80)')
-
+    # if delay_1 == 200 and delay_2 == 100 and timeout == 100 \
+    #         and not expected_signal_triggered \
+    #         and sys.platform.startswith('win32'):
+    #     pytest.skip('crashing on windows (#80)')
     signaller = Signaller()
     single_shot(signaller.signal, delay_1)
     single_shot(signaller.signal_2, delay_2)
@@ -139,9 +135,6 @@ def test_signal_triggered_multiple(qtbot, single_shot, stop_watch, wait_function
     blocker = wait_function(qtbot, [signaller.signal, signaller.signal_2],
                             timeout, multiple=True, raising=raising,
                             should_raise=should_raise)
-
-    # Check that event loop exited.
-    assert not blocker._loop.isRunning()
 
     # ensure that either signal was triggered or timeout occurred
     assert blocker.signal_triggered == expected_signal_triggered

--- a/pytestqt/_tests/test_wait_signal.py
+++ b/pytestqt/_tests/test_wait_signal.py
@@ -123,6 +123,12 @@ def test_signal_triggered_multiple(qtbot, single_shot, stop_watch, wait_function
     Testing for a signal in different conditions, ensuring we are obtaining
     the expected results.
     """
+    import sys
+    if delay_1 == 200 and delay_2 == 100 and timeout == 100 \
+            and not expected_signal_triggered \
+            and sys.platform.startswith('win32'):
+        pytest.skip('crashing on windows (#80)')
+
     signaller = Signaller()
     single_shot(signaller.signal, delay_1)
     single_shot(signaller.signal_2, delay_2)

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py26, py27, py32, py33, py34, docs
 [testenv]
 deps=pytest 
     pyside    
-commands=py.test
+commands=py.test {posargs}
 
 [testenv:docs]
 deps=pytest


### PR DESCRIPTION
As mentioned in #80:

1. I ditched the current wait signal implementation that used QEventLoop and a QTimer in favor of a busy-loop based one. This ensures we never leave the main event loop, and as bonus the code actually got simpler (0130b0f). :sweat_smile:

1. I changed the Signaller class into a fixture, which depends on the fixture that handles timers; this way we are sure Signaller instances outlive the timers, which during shutdown will disconnect from the signals too (157cf3a). Your traceback inspired me to this, as I think it is some weird shutdown order that doesn't happen everytime.

A quick review here is welcome @The-Compiler! :smile:

Fix #76 and #80 