### PR TITLE
Introduce backward compatibility for symbols previously available in pytestqt.plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # 1.6.0.dev #
 
-# 1.5.2.dev #
-
 - Reduced verbosity when exceptions are captured in virtual methods
   (#77, thanks @The-Compiler).
   

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -2,9 +2,17 @@ import pytest
 
 from pytestqt.exceptions import capture_exceptions, format_captured_exceptions, \
     _is_exception_capture_disabled
-from pytestqt.logging import QtLoggingPlugin, _QtMessageCapture
+from pytestqt.logging import QtLoggingPlugin, _QtMessageCapture, Record
 from pytestqt.qt_compat import QApplication, QT_API
 from pytestqt.qtbot import QtBot
+from pytestqt.wait_signal import SignalBlocker, MultiSignalBlocker, SignalTimeoutError
+
+# modules imported here just for backward compatibility before we have split the implementation
+# of this file in several modules
+assert SignalBlocker
+assert MultiSignalBlocker
+assert SignalTimeoutError
+assert Record
 
 
 @pytest.yield_fixture(scope='session')

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -154,6 +154,23 @@ def test_header(testdir):
     ])
 
 
+def test_public_api_backward_compatibility():
+    """
+    Test backward compatibility for version 1.6.0: since then symbols that were available from
+    pytestqt.plugin have been moved to other modules to enhance navigation and maintainability,
+    this test ensures the same symbols are still available from the same imports. (#90)
+    """
+    import pytestqt.plugin
+    assert pytestqt.plugin.QtBot
+    assert pytestqt.plugin.SignalBlocker
+    assert pytestqt.plugin.MultiSignalBlocker
+    assert pytestqt.plugin.SignalTimeoutError
+    assert pytestqt.plugin.format_captured_exceptions
+    assert pytestqt.plugin.capture_exceptions
+    assert pytestqt.plugin.QtLoggingPlugin
+    assert pytestqt.plugin.Record
+
+
 class EventRecorder(QWidget):
 
     """


### PR DESCRIPTION
Fix #90