### PR TITLE
Adjust supported python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
  - PYTEST_VERSION=2.7.2 PYTEST_QT_API=pyqt5
 
 install:
- - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
  - sudo apt-get update
 
  # Xvfb
@@ -30,21 +29,14 @@ install:
  - python scripts/install-qt.py
 
  # PyTest
- - pip uninstall -y pytest
- - pip install pytest==$PYTEST_VERSION
+ - pip install -U pytest==$PYTEST_VERSION
 
  # others
  - pip install coveralls --use-wheel
 
-before_script:
- - export DISPLAY=:99.0
- - sh -e /etc/init.d/xvfb start
- - sleep 3
-
-
 script:
  - python setup.py develop
- - catchsegv coverage run --source=pytestqt setup.py test
+ - catchsegv xvfb-run coverage run --source=pytestqt setup.py test
 
 after_success:
  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 
 python:
+  - "2.6"
   - "2.7"
-  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
   
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
+services: docker  # so we get Ubuntu Trusty with Python 3.4
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
-  - "3.5"
-  
+
 virtualenv:
   system_site_packages: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ env:
 install:
  - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
  - sudo apt-get update
- 
+
+ # Xvfb
+ - sudo apt-get install xvfb
+
  # Qt
  - python scripts/install-qt.py
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ This allows you to test and make sure your view layer is behaving the way you ex
 Requirements
 ============
 
-Python 2.6 or later, including Python 3+.
+Python 2.6+ or 3.3+.
 
 Works with either PySide_, PyQt_ (``PyQt4`` and ``PyQt5``) picking whichever
 is available on the system, giving preference to the first one installed in

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # note that tox expects interpreters to be found at C:\PythonXY,
 # with XY being python version ("27" or "34") for instance
-envlist = py{27,34}-pyqt4, py34-pyqt5, py{26,27,32,33,34}-pyside, docs
+envlist = py{27,34}-pyqt4, py34-pyqt5, py{26,27,33,34}-pyside, docs
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
This tests pytest-qt with all supported Python versions on Travis, and drops
support for Python < 3.3.

3.0 and 3.1 were never tested anyways, and coverage.py 4.0 dropped support for
3.2 so the tests started failing on Travis.