### PR TITLE
Extend log patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 /.tox
 .env*
 .coverage
+/.cache
+/.venv

--- a/pytestqt/logging.py
+++ b/pytestqt/logging.py
@@ -24,7 +24,11 @@ class QtLoggingPlugin(object):
             return
         m = item.get_marker('qt_log_ignore')
         if m:
-            ignore_regexes = m.args
+            if m.kwargs.get('extend', False):
+                config_regexes = self.config.getini('qt_log_ignore')
+                ignore_regexes = config_regexes + list(m.args)
+            else:
+                ignore_regexes = m.args
         else:
             ignore_regexes = self.config.getini('qt_log_ignore')
         item.qt_log_capture = _QtMessageCapture(ignore_regexes)

--- a/pytestqt/logging.py
+++ b/pytestqt/logging.py
@@ -24,6 +24,9 @@ class QtLoggingPlugin(object):
             return
         m = item.get_marker('qt_log_ignore')
         if m:
+            if not set(m.kwargs).issubset(set(['extend'])):
+                raise ValueError("Invalid keyword arguments in {0!r} for "
+                                 "qt_log_ignore mark.".format(m.kwargs))
             if m.kwargs.get('extend', False):
                 config_regexes = self.config.getini('qt_log_ignore')
                 ignore_regexes = config_regexes + list(m.args)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -319,6 +319,7 @@ def test_logging_fails_ignore_mark(testdir, mark_regex):
         """
         [pytest]
         qt_log_level_fail = CRITICAL
+        qt_log_ignore = no-match
         """
     )
     if mark_regex:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -237,7 +237,7 @@ def test_logging_fails_tests_mark(testdir):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning, qCritical, qDebug
+        from pytestqt.qt_compat import qWarning
         import pytest
         @pytest.mark.qt_log_level_fail('WARNING')
         def test_1():
@@ -265,7 +265,7 @@ def test_logging_fails_ignore(testdir):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning, qCritical
+        from pytestqt.qt_compat import qCritical
         import pytest
 
         def test1():
@@ -328,7 +328,7 @@ def test_logging_fails_ignore_mark(testdir, mark_regex):
         mark = ''
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning, qCritical
+        from pytestqt.qt_compat import qCritical
         import pytest
         {mark}
         def test1():
@@ -356,7 +356,7 @@ def test_logging_mark_with_extend(testdir, message):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning, qCritical
+        from pytestqt.qt_compat import qCritical
         import pytest
 
         @pytest.mark.qt_log_ignore('match-mark', extend=True)
@@ -409,7 +409,7 @@ def test_logging_fails_ignore_mark_multiple(testdir, apply_mark):
         mark = ''
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning, qCritical
+        from pytestqt.qt_compat import qCritical
         import pytest
         @pytest.mark.qt_log_level_fail('CRITICAL')
         {mark}

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -340,6 +340,34 @@ def test_logging_fails_ignore_mark(testdir, mark_regex):
     res.assertoutcome(passed=passed, failed=int(not passed))
 
 
+@pytest.mark.parametrize('message', ['match-global', 'match-mark'])
+def test_logging_mark_with_extend(testdir, message):
+    """
+    Test qt_log_ignore mark with extend=True.
+
+    :type testdir: _pytest.pytester.TmpTestdir
+    """
+    testdir.makeini(
+        """
+        [pytest]
+        qt_log_level_fail = CRITICAL
+        qt_log_ignore = match-global
+        """
+    )
+    testdir.makepyfile(
+        """
+        from pytestqt.qt_compat import qWarning, qCritical
+        import pytest
+
+        @pytest.mark.qt_log_ignore('match-mark', extend=True)
+        def test1():
+            qCritical('{message}')
+        """.format(message=message)
+    )
+    res = testdir.inline_run()
+    res.assertoutcome(passed=1, failed=0)
+
+
 @pytest.mark.parametrize('apply_mark', [True, False])
 def test_logging_fails_ignore_mark_multiple(testdir, apply_mark):
     """

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -368,6 +368,34 @@ def test_logging_mark_with_extend(testdir, message):
     res.assertoutcome(passed=1, failed=0)
 
 
+def test_logging_mark_with_invalid_argument(testdir):
+    """
+    Test qt_log_ignore mark with invalid keyword argument.
+
+    :type testdir: _pytest.pytester.TmpTestdir
+    """
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.qt_log_ignore('match-mark', does_not_exist=True)
+        def test1():
+            pass
+        """
+    )
+    res = testdir.runpytest()
+    lines = [
+        '*= ERRORS =*',
+        '*_ ERROR at setup of test1 _*',
+        "*ValueError: Invalid keyword arguments in {'does_not_exist': True} "
+            "for qt_log_ignore mark.",
+
+        # summary
+        '*= 1 error in*',
+    ]
+    res.stdout.fnmatch_lines(lines)
+
+
 @pytest.mark.parametrize('apply_mark', [True, False])
 def test_logging_fails_ignore_mark_multiple(testdir, apply_mark):
     """


### PR DESCRIPTION
There are actually a few unrelated changes in here, but I hope you don't mind (at least they have their own commits :wink:).

* Fix test_logging_fails_ignore_mark.
* Add extend keyword argument to qt_log_ignore mark.
* Validate qt_log_ignore keyword arguments.
* Remove unneeded imports.
* Add .cache and .venv to .gitignore.
