### PR TITLE
Setup/teardown exception capturing as early/late as possible to catch all exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@
   `@The-Compiler`_ for the request.
 
 - Widgets registered by ``qtbot.addWidget`` are now closed  before all other
- fixtures are tear down (`106`_). Thanks `@The-Compiler`_ for request.
+  fixtures are tear down (`106`_). Thanks `@The-Compiler`_ for request.
 
 .. _105: https://github.com/pytest-dev/pytest-qt/issues/105
 .. _106: https://github.com/pytest-dev/pytest-qt/issues/106

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+1.9.0
+-----
+
+- Exception capturing now happens as early/late as possible in order to catch
+  all possible exceptions (including fixtures). Thanks
+  `@The-Compiler`_ for the request (`105`_, `106`_).
+
+.. _105: https://github.com/pytest-dev/pytest-qt/issues/105
+.. _106: https://github.com/pytest-dev/pytest-qt/issues/106
+
+
 1.8.0
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,11 @@
 -----
 
 - Exception capturing now happens as early/late as possible in order to catch
-  all possible exceptions (including fixtures). Thanks
-  `@The-Compiler`_ for the request (`105`_, `106`_).
+  all possible exceptions (including fixtures)(`105`_). Thanks
+  `@The-Compiler`_ for the request.
+
+- Widgets registered by ``qtbot.addWidget`` are now closed  before all other
+ fixtures are tear down (`106`_). Thanks `@The-Compiler`_ for request.
 
 .. _105: https://github.com/pytest-dev/pytest-qt/issues/105
 .. _106: https://github.com/pytest-dev/pytest-qt/issues/106

--- a/pytestqt/exceptions.py
+++ b/pytestqt/exceptions.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import sys
 import traceback
+import pytest
 
 
 @contextmanager
@@ -10,17 +11,54 @@ def capture_exceptions():
     and returns them as a list of (type, value, traceback) after the
     context ends.
     """
-    result = []
-
-    def hook(type_, value, tback):
-        result.append((type_, value, tback))
-
-    old_hook = sys.excepthook
-    sys.excepthook = hook
+    manager = _QtExceptionCaptureManager()
+    manager.start()
     try:
-        yield result
+        yield manager.exceptions
     finally:
-        sys.excepthook = old_hook
+        manager.finish()
+
+
+class _QtExceptionCaptureManager(object):
+    """
+    Manages exception capture context.
+    """
+
+    def __init__(self):
+        self.old_hook = None
+        self.exceptions = []
+
+    def start(self):
+        """Start exception capturing by installing a hook into sys.excepthook
+        that records exceptions received into ``self.exceptions``.
+        """
+        def hook(type_, value, tback):
+            self.exceptions.append((type_, value, tback))
+
+        self.old_hook = sys.excepthook
+        sys.excepthook = hook
+
+    def finish(self):
+        """Stop exception capturing, restoring the original hook.
+
+        Can be called multiple times.
+        """
+        if self.old_hook is not None:
+            sys.excepthook = self.old_hook
+            self.old_hook = None
+
+    def fail_if_exceptions_occurred(self, when):
+        """calls pytest.fail() with an informative message if exceptions
+        have been captured so far. Before pytest.fail() is called, also
+        finish capturing.
+        """
+        if self.exceptions:
+            self.finish()
+            exceptions = self.exceptions[:]
+            self.exceptions[:] = []
+            prefix = '%s ERROR: ' % when
+            pytest.fail(prefix + format_captured_exceptions(exceptions),
+                        pytrace=False)
 
 
 def format_captured_exceptions(exceptions):
@@ -42,3 +80,6 @@ def _is_exception_capture_disabled(item):
     """
     return item.get_marker('qt_no_exception_capture') or \
            item.config.getini('qt_no_exception_capture')
+
+def _is_exception_capture_enabled(item):
+    return not _is_exception_capture_disabled(item)

--- a/pytestqt/exceptions.py
+++ b/pytestqt/exceptions.py
@@ -54,8 +54,8 @@ class _QtExceptionCaptureManager(object):
         """
         if self.exceptions:
             self.finish()
-            exceptions = self.exceptions[:]
-            self.exceptions[:] = []
+            exceptions = self.exceptions
+            self.exceptions = []
             prefix = '%s ERROR: ' % when
             pytest.fail(prefix + format_captured_exceptions(exceptions),
                         pytrace=False)

--- a/pytestqt/exceptions.py
+++ b/pytestqt/exceptions.py
@@ -75,11 +75,9 @@ def format_captured_exceptions(exceptions):
     return message
 
 
-def _is_exception_capture_disabled(item):
+def _is_exception_capture_enabled(item):
     """returns if exception capture is disabled for the given test item.
     """
-    return item.get_marker('qt_no_exception_capture') or \
-           item.config.getini('qt_no_exception_capture')
-
-def _is_exception_capture_enabled(item):
-    return not _is_exception_capture_disabled(item)
+    disabled = item.get_marker('qt_no_exception_capture') or \
+               item.config.getini('qt_no_exception_capture')
+    return not disabled

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -83,7 +83,8 @@ def pytest_addoption(parser):
                          'default: "{0}"'.format(default))
 
 
-@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+@pytest.mark.hookwrapper
+@pytest.mark.tryfirst
 def pytest_runtest_setup(item):
     """
     Hook called after before test setup starts, to start capturing exceptions

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -99,7 +99,8 @@ def pytest_runtest_setup(item):
         item.qt_exception_capture_manager.fail_if_exceptions_occurred('SETUP')
 
 
-@pytest.hookimpl(hookwrapper=True, trylast=True)
+@pytest.mark.hookwrapper
+@pytest.mark.tryfirst
 def pytest_runtest_call(item):
     yield
     _process_events(item)
@@ -108,7 +109,8 @@ def pytest_runtest_call(item):
         item.qt_exception_capture_manager.fail_if_exceptions_occurred('CALL')
 
 
-@pytest.hookimpl(hookwrapper=True, trylast=True)
+@pytest.mark.hookwrapper
+@pytest.mark.trylast
 def pytest_runtest_teardown(item):
     """
     Hook called after each test tear down, to process any pending events and

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -1,19 +1,20 @@
 import pytest
 
 from pytestqt.exceptions import capture_exceptions, format_captured_exceptions, \
-    _is_exception_capture_disabled, _is_exception_capture_enabled, \
-    _QtExceptionCaptureManager
+    _is_exception_capture_enabled, _QtExceptionCaptureManager
 from pytestqt.logging import QtLoggingPlugin, _QtMessageCapture, Record
 from pytestqt.qt_compat import QApplication, QT_API
 from pytestqt.qtbot import QtBot, _close_widgets
 from pytestqt.wait_signal import SignalBlocker, MultiSignalBlocker, SignalTimeoutError
 
-# modules imported here just for backward compatibility before we have split the implementation
-# of this file in several modules
+# classes/functions imported here just for backward compatibility before we
+# split the implementation of this file in several modules
 assert SignalBlocker
 assert MultiSignalBlocker
 assert SignalTimeoutError
 assert Record
+assert capture_exceptions
+assert format_captured_exceptions
 
 
 @pytest.yield_fixture(scope='session')
@@ -93,7 +94,7 @@ def pytest_runtest_setup(item):
         item.qt_exception_capture_manager = _QtExceptionCaptureManager()
         item.qt_exception_capture_manager.start()
     yield
-    _process_events(item)
+    _process_events()
     if capture_enabled:
         item.qt_exception_capture_manager.fail_if_exceptions_occurred('SETUP')
 
@@ -102,7 +103,7 @@ def pytest_runtest_setup(item):
 @pytest.mark.tryfirst
 def pytest_runtest_call(item):
     yield
-    _process_events(item)
+    _process_events()
     capture_enabled = _is_exception_capture_enabled(item)
     if capture_enabled:
         item.qt_exception_capture_manager.fail_if_exceptions_occurred('CALL')
@@ -116,18 +117,18 @@ def pytest_runtest_teardown(item):
     avoiding leaking events to the next test. Also, if exceptions have
     been captured during fixtures teardown, fail the test.
     """
-    _process_events(item)
+    _process_events()
     _close_widgets(item)
-    _process_events(item)
+    _process_events()
     yield
-    _process_events(item)
+    _process_events()
     capture_enabled = _is_exception_capture_enabled(item)
     if capture_enabled:
         item.qt_exception_capture_manager.fail_if_exceptions_occurred('TEARDOWN')
         item.qt_exception_capture_manager.finish()
 
 
-def _process_events(item):
+def _process_events():
     """Calls app.processEvents() while taking care of capturing exceptions
     or not based on the given item's configuration.
     """


### PR DESCRIPTION
Now exception capturing is setup as early as possible, and disabled as late as possible. Also, this new approach allows us to distinguish exceptions captured during setup/call/teardown, which provides a more friendly message when the exception occurred inside the test call (as opposed during `qtbot`'s teardown).

Fixes #105
Fixes #106