### PR TITLE
Add an 'args' attribute to SignalBlocker.

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -43,6 +43,22 @@ reached before the signal is triggered:
         assert_application_results(app)
 
 
+**Getting arguments of the emitted signal**
+
+.. versionadded:: 1.10
+
+The arguments emitted with the signal are available as the ``args`` attribute
+of the blocker:
+
+
+.. code-block:: python
+
+    def test_signal(qtbot):
+        ...
+        with qtbot.waitSignal(app.got_cmd) as blocker:
+            app.listen()
+        assert blocker.args == ['test']
+
 
 **waitSignals**
 

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -1,5 +1,5 @@
 import functools
-from pytestqt.qt_compat import QtCore
+from pytestqt.qt_compat import QtCore, QtTest
 
 
 class _AbstractSignalBlocker(object):
@@ -86,6 +86,13 @@ class SignalBlocker(_AbstractSignalBlocker):
     :ivar bool raising:
         If :class:`SignalTimeoutError` should be raised if a timeout occurred.
 
+    :ivar list args:
+        The arguments which were emitted by the signal, or None if the signal
+        wasn't emitted at all.
+
+    .. versionadded:: 1.10
+       The *args* attribute.
+
     .. automethod:: wait
     .. automethod:: connect
     """
@@ -93,6 +100,8 @@ class SignalBlocker(_AbstractSignalBlocker):
     def __init__(self, timeout=1000, raising=False):
         super(SignalBlocker, self).__init__(timeout, raising=raising)
         self._signals = []
+        self._spy = None
+        self.args = None
 
     def connect(self, signal):
         """
@@ -104,6 +113,11 @@ class SignalBlocker(_AbstractSignalBlocker):
 
         :param signal: QtCore.Signal
         """
+        # Note we have to connect the spy *first* so the arguments are
+        # available when _quit_loop_by_signal is run.
+        if self._spy is None:
+            self._spy = QtTest.QSignalSpy(signal)
+            assert self._spy.isValid()
         signal.connect(self._quit_loop_by_signal)
         self._signals.append(signal)
 
@@ -112,6 +126,11 @@ class SignalBlocker(_AbstractSignalBlocker):
         quits the event loop and marks that we finished because of a signal.
         """
         self.signal_triggered = True
+        if self._spy:
+            # signal was emitted once at this point, because we disconnect
+            # _quit_loop_by_signal here.
+            assert len(self._spy) == 1
+            self.args = list(self._spy[0])
         self._loop.quit()
         self._cleanup()
 

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -307,8 +307,8 @@ class TestArgs:
             blocker.args
 
     def test_connected_signal(self, qtbot, signaller):
-        """A signal connected via .connect is ignored for args."""
+        """A second signal connected via .connect also works."""
         with qtbot.waitSignal(signaller.signal_args) as blocker:
             blocker.connect(signaller.signal_args_2)
             signaller.signal_args_2.emit('foo', 2342)
-        assert blocker.args is None
+        assert blocker.args == ['foo', 2342]


### PR DESCRIPTION
Closes #64.

Maybe #114 needs a look first though - if there's anything wrong in the logic in `_quit_loop_by_signal` we'll just get a hang otherwise.

I have only tested on PyQt5.