### PR TITLE
[WIP] Add an option for the raising default

### DIFF
--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -60,6 +60,9 @@ def qtlog(request):
 def pytest_addoption(parser):
     parser.addini('qt_no_exception_capture',
                   'disable automatic exception capture')
+    parser.addini('qt_wait_signal_raising',
+                  'Raise an exception by default when qtbot.waitSignal times '
+                      'out')
 
     default_log_fail = QtLoggingPlugin.LOG_FAIL_OPTIONS[0]
     parser.addini('qt_log_level_fail',

--- a/pytestqt/qtbot.py
+++ b/pytestqt/qtbot.py
@@ -218,7 +218,7 @@ class QtBot(object):
 
     stop = stopForInteraction
 
-    def waitSignal(self, signal=None, timeout=1000, raising=False):
+    def waitSignal(self, signal=None, timeout=1000, raising=None):
         """
         .. versionadded:: 1.2
 
@@ -266,7 +266,7 @@ class QtBot(object):
 
     wait_signal = waitSignal  # pep-8 alias
 
-    def waitSignals(self, signals=None, timeout=1000, raising=False):
+    def waitSignals(self, signals=None, timeout=1000, raising=None):
         """
         .. versionadded:: 1.4
 


### PR DESCRIPTION
This is heavily work-in-progress (incomplete tests, `pytest.config` usage which is deprecated I think?), but already giving me headaches :wink:

It seems e.g. `TestArgs.test_timeout` fails, with `raising` set to `true` from the previous `testdir` run?!

```
___________________________________________________ TestArgs.test_timeout ____________________________________________________

self = <test_wait_signal.TestArgs object at 0x7f0c38c866d8>, qtbot = <pytestqt.qtbot.QtBot object at 0x7f0c38c865c0>

    def test_timeout(self, qtbot):
        """If there's a timeout, the args attribute is None."""
        with qtbot.waitSignal(timeout=100) as blocker:
>           pass

test_wait_signal.py:340: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../.tox/py35-pyqt5/lib/python3.5/site-packages/pytestqt/wait_signal.py:78: in __exit__
    self.wait()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pytestqt.wait_signal.SignalBlocker object at 0x7f0c3b779828>

    def wait(self):
        """
            Waits until either a connected signal is triggered or timeout is reached.
    
            :raise ValueError: if no signals are connected and timeout is None; in
                this case it would wait forever.
            """
        if self.signal_triggered:
            return
        if self.timeout is None and not self._signals:
            raise ValueError("No signals or timeout specified.")
        if self._timer is not None:
            self._timer.timeout.connect(self._quit_loop_by_timeout)
            self._timer.start()
        self._loop.exec_()
        if not self.signal_triggered and self.raising:
            print("raising: {!r}".format(self.raising))
            raise SignalTimeoutError("Didn't get signal after %sms." %
>                                    self.timeout)
E           pytestqt.wait_signal.SignalTimeoutError: Didn't get signal after 100ms.

../.tox/py35-pyqt5/lib/python3.5/site-packages/pytestqt/wait_signal.py:58: SignalTimeoutError
---------------------------------------------------- Captured stdout call ----------------------------------------------------
raising: 'true'
```

Do you have an idea what's happening there? Or is this exactly why I shouldn't use `pytest.config`? Any other good way to access the config inside `_AbstractSignalBlocker`?
