### PR TITLE
Fix syntax of `tests_require` option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
         'Topic :: Software Development :: Testing',
         'Topic :: Software Development :: User Interfaces',
     ],
-    tests_requires=['pytest'],
+    tests_require=['pytest'],
     cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
Confusingly, the option has no trailing 's' like `install_requires`.

See:

* https://pythonhosted.org/setuptools/setuptools.html
* https://travis-ci.org/pytest-dev/pytest-qt/jobs/100969573#L363