### PR TITLE
Configure Qt API using config file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,8 +37,19 @@ New Features
   is met or a timeout is reached. Useful for testing some features in X window environments
   due to its asynchronous nature.
 
+* Now which Qt binding ``pytest-qt`` should use can be configured by the ``qt_api`` config option.
+  Thanks `@The-Compiler`_ for the request (`#129`_).
+
+- ``PYTEST_QT_FORCE_PYQT`` environment variable is no longer supported.
+
+- While ``pytestqt.qt_compat`` is an internal module and shouldn't be imported directly,
+  it is known that some test suites did import it. This module now uses a lazy-load mechanism
+  to load Qt classes and objects, so the old symbols (``QtCore``, ``QApplication``, etc.) are
+  no longer available from it.
+
 .. _#134: https://github.com/pytest-dev/pytest-qt/issues/134
 .. _#63: https://github.com/pytest-dev/pytest-qt/pull/63
+.. _#129: https://github.com/pytest-dev/pytest-qt/issues/129
 
 
 Other Changes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ However, this required some backwards-incompatible changes:
   on timeouts. You can set ``qt_wait_signal_raising = false`` in your config to
   get back the old behaviour.
 
+- ``PYTEST_QT_FORCE_PYQT`` environment variable is no longer supported. Set ``PYTEST_QT_API``
+  to the appropriate value instead.
+
 
 New Features
 ~~~~~~~~~~~~
@@ -39,8 +42,6 @@ New Features
 
 * Now which Qt binding ``pytest-qt`` should use can be configured by the ``qt_api`` config option.
   Thanks `@The-Compiler`_ for the request (`#129`_).
-
-- ``PYTEST_QT_FORCE_PYQT`` environment variable is no longer supported.
 
 - While ``pytestqt.qt_compat`` is an internal module and shouldn't be imported directly,
   it is known that some test suites did import it. This module now uses a lazy-load mechanism

--- a/README.rst
+++ b/README.rst
@@ -80,9 +80,20 @@ this order:
 - ``PySide``
 - ``PyQt4``
 
-To force a particular API, set the environment variable ``PYTEST_QT_API`` to
-``pyqt5``, ``pyside``, ``pyqt4``, or ``pyqt4v2``. ``pyqt4v2`` sets the ``PyQt4``
-API to `version 2 <http://pyqt.sourceforge.net/Docs/PyQt4/incompatible_apis.html>`_.
+To force a particular API, set the configuration variable ``qt_api`` in your ``pytest.ini`` file to
+``pyqt5``, ``pyside``, ``pyqt4`` or ``pyqt4v2``. ``pyqt4v2`` sets the ``PyQt4``
+API to `version 2 <version2>`_.
+
+.. code-block:: ini
+    [pytest]
+    qt_api=pyqt5
+
+
+Alternatively, you can set the ``PYTEST_QT_API`` environment
+variable to the same values described above (the environment variable wins over the configuration
+if both are set).
+
+.. _version2: http://pyqt.sourceforge.net/Docs/PyQt4/incompatible_apis.html
 
 
 Documentation

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -38,9 +38,19 @@ this order:
 - ``PySide``
 - ``PyQt4``
 
-To force a particular API, set the environment variable ``PYTEST_QT_API`` to
+To force a particular API, set the configuration variable ``qt_api`` in your ``pytest.ini`` file to
 ``pyqt5``, ``pyside``, ``pyqt4`` or ``pyqt4v2``. ``pyqt4v2`` sets the ``PyQt4``
-API to `version 2 <version2>`_
+API to `version 2 <version2>`_.
+
+.. code-block:: ini
+
+    [pytest]
+    qt_api=pyqt5
+
+
+Alternatively, you can set the ``PYTEST_QT_API`` environment
+variable to the same values described above (the environment variable wins over the configuration
+if both are set).
 
 .. _version2: http://pyqt.sourceforge.net/Docs/PyQt4/incompatible_apis.html
 

--- a/pytestqt/modeltest.py
+++ b/pytestqt/modeltest.py
@@ -34,8 +34,7 @@
 from __future__ import print_function
 import collections
 
-from pytestqt.qt_compat import QtCore, QtGui, extract_from_variant, \
-    QAbstractListModel, QAbstractTableModel
+from pytestqt.qt_compat import qt_api
 
 
 _Changing = collections.namedtuple('_Changing', 'parent, old_size, last, next')
@@ -65,10 +64,10 @@ class ModelTester:
         if not index.isValid():
             return '<invalid> (0x{:x})'.format(id(index))
         else:
-            data = self._model.data(index, QtCore.Qt.DisplayRole)
+            data = self._model.data(index, qt_api.QtCore.Qt.DisplayRole)
             return '{}/{} {!r} (0x{:x})'.format(
                 index.row(), index.column(),
-                extract_from_variant(data),
+                qt_api.extract_from_variant(data),
                 id(index))
 
     def check(self, model):
@@ -166,31 +165,31 @@ class ModelTester:
         Make sure the model doesn't outright segfault, testing the functions
         which make sense.
         """
-        assert self._model.buddy(QtCore.QModelIndex()) == QtCore.QModelIndex()
-        self._model.canFetchMore(QtCore.QModelIndex())
-        assert self._column_count(QtCore.QModelIndex()) >= 0
-        display_data = self._model.data(QtCore.QModelIndex(),
-                                        QtCore.Qt.DisplayRole)
+        assert self._model.buddy(qt_api.QtCore.QModelIndex()) == qt_api.QtCore.QModelIndex()
+        self._model.canFetchMore(qt_api.QtCore.QModelIndex())
+        assert self._column_count(qt_api.QtCore.QModelIndex()) >= 0
+        display_data = self._model.data(qt_api.QtCore.QModelIndex(),
+                                        qt_api.QtCore.Qt.DisplayRole)
 
-        assert extract_from_variant(display_data) is None
-        self._fetch_more(QtCore.QModelIndex())
-        flags = self._model.flags(QtCore.QModelIndex())
-        assert flags == QtCore.Qt.ItemIsDropEnabled or not flags
-        self._has_children(QtCore.QModelIndex())
+        assert qt_api.extract_from_variant(display_data) is None
+        self._fetch_more(qt_api.QtCore.QModelIndex())
+        flags = self._model.flags(qt_api.QtCore.QModelIndex())
+        assert flags == qt_api.QtCore.Qt.ItemIsDropEnabled or not flags
+        self._has_children(qt_api.QtCore.QModelIndex())
         self._model.hasIndex(0, 0)
-        self._model.headerData(0, QtCore.Qt.Horizontal)
+        self._model.headerData(0, qt_api.QtCore.Qt.Horizontal)
         self._model.index(0, 0)
-        self._model.itemData(QtCore.QModelIndex())
+        self._model.itemData(qt_api.QtCore.QModelIndex())
         cache = None
-        self._model.match(QtCore.QModelIndex(), -1, cache)
+        self._model.match(qt_api.QtCore.QModelIndex(), -1, cache)
         self._model.mimeTypes()
-        assert self._parent(QtCore.QModelIndex()) == QtCore.QModelIndex()
+        assert self._parent(qt_api.QtCore.QModelIndex()) == qt_api.QtCore.QModelIndex()
         assert self._model.rowCount() >= 0
-        self._model.setData(QtCore.QModelIndex(), None, -1)
-        self._model.setHeaderData(-1, QtCore.Qt.Horizontal, None)
-        self._model.setHeaderData(999999, QtCore.Qt.Horizontal, None)
-        self._model.sibling(0, 0, QtCore.QModelIndex())
-        self._model.span(QtCore.QModelIndex())
+        self._model.setData(qt_api.QtCore.QModelIndex(), None, -1)
+        self._model.setHeaderData(-1, qt_api.QtCore.Qt.Horizontal, None)
+        self._model.setHeaderData(999999, qt_api.QtCore.Qt.Horizontal, None)
+        self._model.sibling(0, 0, qt_api.QtCore.QModelIndex())
+        self._model.span(qt_api.QtCore.QModelIndex())
         self._model.supportedDropActions()
 
     def _test_row_count(self):
@@ -202,7 +201,7 @@ class ModelTester:
         but this catches the big mistakes.
         """
         # check top row
-        top_index = self._model.index(0, 0, QtCore.QModelIndex())
+        top_index = self._model.index(0, 0, qt_api.QtCore.QModelIndex())
         rows = self._model.rowCount(top_index)
         assert rows >= 0
         if rows > 0:
@@ -223,7 +222,7 @@ class ModelTester:
         but this catches the big mistakes.
         """
         # check top row
-        top_index = self._model.index(0, 0, QtCore.QModelIndex())
+        top_index = self._model.index(0, 0, qt_api.QtCore.QModelIndex())
         assert self._column_count(top_index) >= 0
 
         # check a column count where parent is valid
@@ -259,9 +258,9 @@ class ModelTester:
         but this catches the big mistakes.
         """
         # Make sure that invalid values return an invalid index
-        assert self._model.index(-2, -2) == QtCore.QModelIndex()
-        assert self._model.index(-2, 0) == QtCore.QModelIndex()
-        assert self._model.index(0, -2) == QtCore.QModelIndex()
+        assert self._model.index(-2, -2) == qt_api.QtCore.QModelIndex()
+        assert self._model.index(-2, 0) == qt_api.QtCore.QModelIndex()
+        assert self._model.index(0, -2) == qt_api.QtCore.QModelIndex()
 
         rows = self._model.rowCount()
         columns = self._column_count()
@@ -270,7 +269,7 @@ class ModelTester:
             return
 
         # Catch off by one errors
-        assert self._model.index(rows, columns) == QtCore.QModelIndex()
+        assert self._model.index(rows, columns) == qt_api.QtCore.QModelIndex()
         assert self._model.index(0, 0).isValid()
 
         # Make sure that the same index is *always* returned
@@ -282,7 +281,7 @@ class ModelTester:
         """Tests model's implementation of QAbstractItemModel::parent()."""
         # Make sure the model won't crash and will return an invalid
         # QModelIndex when asked for the parent of an invalid index.
-        assert self._parent(QtCore.QModelIndex()) == QtCore.QModelIndex()
+        assert self._parent(qt_api.QtCore.QModelIndex()) == qt_api.QtCore.QModelIndex()
 
         if self._model.rowCount() == 0:
             return
@@ -294,8 +293,8 @@ class ModelTester:
 
         # Common error test #1, make sure that a top level index has a parent
         # that is a invalid QModelIndex.
-        top_index = self._model.index(0, 0, QtCore.QModelIndex())
-        assert self._parent(top_index) == QtCore.QModelIndex()
+        top_index = self._model.index(0, 0, qt_api.QtCore.QModelIndex())
+        assert self._parent(top_index) == qt_api.QtCore.QModelIndex()
 
         # Common error test #2, make sure that a second level index has a
         # parent that is the first level index.
@@ -306,7 +305,7 @@ class ModelTester:
         # Common error test #3, the second column should NOT have the same
         # children as the first column in a row.
         # Usually the second column shouldn't have children.
-        top_index_1 = self._model.index(0, 1, QtCore.QModelIndex())
+        top_index_1 = self._model.index(0, 1, qt_api.QtCore.QModelIndex())
         if self._model.rowCount(top_index_1) > 0:
             child_index = self._model.index(0, 0, top_index)
             child_index_1 = self._model.index(0, 0, top_index_1)
@@ -314,7 +313,7 @@ class ModelTester:
 
         # Full test, walk n levels deep through the model making sure that all
         # parent's children correctly specify their parent.
-        self._check_children(QtCore.QModelIndex())
+        self._check_children(qt_api.QtCore.QModelIndex())
 
     def _check_children(self, parent, current_depth=0):
         """Check parent/children relationships.
@@ -392,9 +391,9 @@ class ModelTester:
                 assert index.row() == r
                 assert index.column() == c
 
-                data = self._model.data(index, QtCore.Qt.DisplayRole)
+                data = self._model.data(index, qt_api.QtCore.Qt.DisplayRole)
                 if not self.data_display_may_return_none:
-                    assert extract_from_variant(data) is not None
+                    assert qt_api.extract_from_variant(data) is not None
 
                 # If the next test fails here is some somewhat useful debug you
                 # play with.
@@ -429,8 +428,8 @@ class ModelTester:
     def _test_data(self):
         """Test model's implementation of data()"""
         # Invalid index should return an invalid qvariant
-        value = self._model.data(QtCore.QModelIndex(), QtCore.Qt.DisplayRole)
-        assert extract_from_variant(value) is None
+        value = self._model.data(qt_api.QtCore.QModelIndex(), qt_api.QtCore.Qt.DisplayRole)
+        assert qt_api.extract_from_variant(value) is None
 
         if self._model.rowCount() == 0:
             return
@@ -439,18 +438,18 @@ class ModelTester:
         assert self._model.index(0, 0).isValid()
 
         # shouldn't be able to set data on an invalid index
-        ok = self._model.setData(QtCore.QModelIndex(), "foo",
-                                 QtCore.Qt.DisplayRole)
+        ok = self._model.setData(qt_api.QtCore.QModelIndex(), "foo",
+                                 qt_api.QtCore.Qt.DisplayRole)
         assert not ok
 
         types = [
-            (QtCore.Qt.ToolTipRole, str),
-            (QtCore.Qt.StatusTipRole, str),
-            (QtCore.Qt.WhatsThisRole, str),
-            (QtCore.Qt.SizeHintRole, QtCore.QSize),
-            (QtCore.Qt.FontRole, QtGui.QFont),
-            (QtCore.Qt.BackgroundColorRole, QtGui.QColor),
-            (QtCore.Qt.TextColorRole, QtGui.QColor),
+            (qt_api.QtCore.Qt.ToolTipRole, str),
+            (qt_api.QtCore.Qt.StatusTipRole, str),
+            (qt_api.QtCore.Qt.WhatsThisRole, str),
+            (qt_api.QtCore.Qt.SizeHintRole, qt_api.QtCore.QSize),
+            (qt_api.QtCore.Qt.FontRole, qt_api.QtGui.QFont),
+            (qt_api.QtCore.Qt.BackgroundColorRole, qt_api.QtGui.QColor),
+            (qt_api.QtCore.Qt.TextColorRole, qt_api.QtGui.QColor),
         ]
 
         # General purpose roles with a fixed expected type
@@ -460,22 +459,22 @@ class ModelTester:
 
         # Check that the alignment is one we know about
         alignment = self._model.data(self._model.index(0, 0),
-                                     QtCore.Qt.TextAlignmentRole)
-        alignment = extract_from_variant(alignment)
+                                     qt_api.QtCore.Qt.TextAlignmentRole)
+        alignment = qt_api.extract_from_variant(alignment)
         if alignment is not None:
             try:
                 alignment = int(alignment)
             except (TypeError, ValueError):
                 assert 0, '%r should be a TextAlignmentRole enum' % alignment
-            mask = int(QtCore.Qt.AlignHorizontal_Mask |
-                       QtCore.Qt.AlignVertical_Mask)
+            mask = int(qt_api.QtCore.Qt.AlignHorizontal_Mask |
+                       qt_api.QtCore.Qt.AlignVertical_Mask)
             assert alignment == alignment & mask
 
         # Check that the "check state" is one we know about.
         state = self._model.data(self._model.index(0, 0),
-                                 QtCore.Qt.CheckStateRole)
-        assert state in [None, QtCore.Qt.Unchecked, QtCore.Qt.PartiallyChecked,
-                         QtCore.Qt.Checked]
+                                 qt_api.QtCore.Qt.CheckStateRole)
+        assert state in [None, qt_api.QtCore.Qt.Unchecked, qt_api.QtCore.Qt.PartiallyChecked,
+                         qt_api.QtCore.Qt.Checked]
 
     def _on_rows_about_to_be_inserted(self, parent, start, end):
         """Store what is about to be inserted.
@@ -516,8 +515,8 @@ class ModelTester:
                     "next data {!r}, last data {!r}".format(
                         self._modelindex_debug(c.parent),
                         c.old_size, expected_size,
-                        extract_from_variant(c.next),
-                        extract_from_variant(c.last)
+                        qt_api.extract_from_variant(c.next),
+                        qt_api.extract_from_variant(c.last)
                     )
         )
 
@@ -525,12 +524,12 @@ class ModelTester:
                     "next data {!r}, last data {!r}".format(
                         self._modelindex_debug(parent),
                         current_size,
-                        extract_from_variant(next_data),
-                        extract_from_variant(last_data)
+                        qt_api.extract_from_variant(next_data),
+                        qt_api.extract_from_variant(last_data)
                     )
         )
 
-        if not QtCore.qVersion().startswith('4.'):
+        if not qt_api.QtCore.qVersion().startswith('4.'):
             # Skipping this on Qt4 as the parent changes for some reason:
             # modeltest: rows about to be inserted: [...]
             #            parent <invalid> (0x7f8f540eacf8), [...]
@@ -553,7 +552,7 @@ class ModelTester:
 
     def _on_layout_about_to_be_changed(self):
         for i in range(max(self._model.rowCount(), 100)):
-            idx = QtCore.QPersistentModelIndex(self._model.index(i, 0))
+            idx = qt_api.QtCore.QPersistentModelIndex(self._model.index(i, 0))
             self._changing.append(idx)
 
     def _on_layout_changed(self):
@@ -600,8 +599,8 @@ class ModelTester:
                     "next data {!r}, last data {!r}".format(
                         self._modelindex_debug(c.parent),
                         c.old_size, expected_size,
-                        extract_from_variant(c.next),
-                        extract_from_variant(c.last)
+                        qt_api.extract_from_variant(c.next),
+                        qt_api.extract_from_variant(c.last)
                     )
         )
 
@@ -609,12 +608,12 @@ class ModelTester:
                     "next data {!r}, last data {!r}".format(
                         self._modelindex_debug(parent),
                         current_size,
-                        extract_from_variant(next_data),
-                        extract_from_variant(last_data)
+                        qt_api.extract_from_variant(next_data),
+                        qt_api.extract_from_variant(last_data)
                     )
         )
 
-        if not QtCore.qVersion().startswith('4.'):
+        if not qt_api.QtCore.qVersion().startswith('4.'):
             # Skipping this on Qt4 as the parent changes for some reason
             # see _on_rows_inserted for details
             assert c.parent == parent
@@ -636,24 +635,24 @@ class ModelTester:
         assert bottom_right.column() < column_count
 
     def _on_header_data_changed(self, orientation, start, end):
-        assert orientation in [QtCore.Qt.Horizontal, QtCore.Qt.Vertical]
+        assert orientation in [qt_api.QtCore.Qt.Horizontal, qt_api.QtCore.Qt.Vertical]
         assert start >= 0
         assert end >= 0
         assert start <= end
-        if orientation == QtCore.Qt.Vertical:
+        if orientation == qt_api.QtCore.Qt.Vertical:
             item_count = self._model.rowCount()
         else:
             item_count = self._column_count()
         assert start < item_count
         assert end < item_count
 
-    def _column_count(self, parent=QtCore.QModelIndex()):
+    def _column_count(self, parent=qt_api.QtCore.QModelIndex()):
         """
         Workaround for the fact that ``columnCount`` is a private method in
-        QAbstractListModel/QAbstractTableModel subclasses.
+        qt_api.QAbstractListModel/qt_api.QAbstractTableModel subclasses.
         """
-        if isinstance(self._model, QAbstractListModel):
-            return 1 if parent == QtCore.QModelIndex() else 0
+        if isinstance(self._model, qt_api.QAbstractListModel):
+            return 1 if parent == qt_api.QtCore.QModelIndex() else 0
         else:
             return self._model.columnCount(parent)
 
@@ -661,19 +660,19 @@ class ModelTester:
         """
         .. see:: ``_column_count``
         """
-        model_types = (QAbstractListModel, QAbstractTableModel)
+        model_types = (qt_api.QAbstractListModel, qt_api.QAbstractTableModel)
         if isinstance(self._model, model_types):
-            return QtCore.QModelIndex()
+            return qt_api.QtCore.QModelIndex()
         else:
             return self._model.parent(index)
 
-    def _has_children(self, parent=QtCore.QModelIndex()):
+    def _has_children(self, parent=qt_api.QtCore.QModelIndex()):
         """
         .. see:: ``_column_count``
         """
-        model_types = (QAbstractListModel, QAbstractTableModel)
+        model_types = (qt_api.QAbstractListModel, qt_api.QAbstractTableModel)
         if isinstance(self._model, model_types):
-            return parent == QtCore.QModelIndex() and self._model.rowCount() > 0
+            return parent == qt_api.QtCore.QModelIndex() and self._model.rowCount() > 0
         else:
             return self._model.hasChildren(parent)
 

--- a/pytestqt/modeltest.py
+++ b/pytestqt/modeltest.py
@@ -649,7 +649,7 @@ class ModelTester:
     def _column_count(self, parent=qt_api.QtCore.QModelIndex()):
         """
         Workaround for the fact that ``columnCount`` is a private method in
-        qt_api.QAbstractListModel/qt_api.QAbstractTableModel subclasses.
+        QAbstractListModel/QAbstractTableModel subclasses.
         """
         if isinstance(self._model, qt_api.QAbstractListModel):
             return 1 if parent == qt_api.QtCore.QModelIndex() else 0

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -16,12 +16,13 @@ import os
 
 VersionTuple = namedtuple('VersionTuple', 'qt_api, qt_api_version, runtime, compiled')
 
+
 class _QtApi:
     """
     Interface to the underlying Qt API currently configured for pytest-qt.
 
-    This object lazily loads all class references and other objects upon the ``set_qt_api`` method,
-    providing a uniform way to access the Qt classes.
+    This object lazily loads all class references and other objects when the ``set_qt_api`` method
+    gets called, providing a uniform way to access the Qt classes.
     """
 
     def _get_qt_api_from_env(self):

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -68,7 +68,7 @@ class _QtApi:
             m = __import__(_root_module, globals(), locals(), [module_name], 0)
             return getattr(m, module_name)
 
-        if self.pytest_qt_api == 'pyqt4v2':
+        if self.pytest_qt_api == 'pyqt4v2':  # pragma: no cover
             # the v2 api in PyQt4
             # http://pyqt.sourceforge.net/Docs/PyQt4/incompatible_apis.html
             import sip

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -142,9 +142,7 @@ class _QtApi:
                 self.QSortFilterProxyModel = QtCore.QSortFilterProxyModel
 
                 def extract_from_variant(variant):
-                    """returns python object from the given QVariant"""
-                    if isinstance(variant, QtCore.QVariant):
-                        return variant.value()
+                    """not needed in PyQt5: Qt API always returns pure python objects"""
                     return variant
 
                 def make_variant(value=None):

--- a/pytestqt/qtbot.py
+++ b/pytestqt/qtbot.py
@@ -1,9 +1,8 @@
 import functools
 import contextlib
 import weakref
-from pytestqt.wait_signal import SignalBlocker, MultiSignalBlocker, SignalTimeoutError, \
-    SignalEmittedSpy
-from pytestqt.qt_compat import QtTest, QApplication
+from pytestqt.wait_signal import SignalBlocker, MultiSignalBlocker, SignalTimeoutError, SignalEmittedSpy
+from pytestqt.qt_compat import qt_api
 
 
 def _parse_ini_boolean(value):
@@ -15,51 +14,6 @@ def _parse_ini_boolean(value):
         raise ValueError('unknown string for bool: %r' % value)
 
 
-def _inject_qtest_methods(cls):
-    """
-    Injects QTest methods into the given class QtBot, so the user can access
-    them directly without having to import QTest.
-    """
-
-    def create_qtest_proxy_method(method_name):
-
-        if hasattr(QtTest.QTest, method_name):
-            qtest_method = getattr(QtTest.QTest, method_name)
-
-            def result(*args, **kwargs):
-                return qtest_method(*args, **kwargs)
-
-            functools.update_wrapper(result, qtest_method)
-            return staticmethod(result)
-        else:
-            return None  # pragma: no cover
-
-    # inject methods from QTest into QtBot
-    method_names = [
-        'keyPress',
-        'keyClick',
-        'keyClicks',
-        'keyEvent',
-        'keyPress',
-        'keyRelease',
-        'keyToAscii',
-
-        'mouseClick',
-        'mouseDClick',
-        'mouseEvent',
-        'mouseMove',
-        'mousePress',
-        'mouseRelease',
-    ]
-    for method_name in method_names:
-        method = create_qtest_proxy_method(method_name)
-        if method is not None:
-            setattr(cls, method_name, method)
-
-    return cls
-
-
-@_inject_qtest_methods
 class QtBot(object):
     """
     Instances of this class are responsible for sending events to `Qt` objects (usually widgets),
@@ -200,12 +154,12 @@ class QtBot(object):
 
         .. note:: This method is also available as ``wait_for_window_shown`` (pep-8 alias)
         """
-        if hasattr(QtTest.QTest, 'qWaitForWindowShown'):  # pragma: no cover
+        if hasattr(qt_api.QtTest.QTest, 'qWaitForWindowShown'):  # pragma: no cover
             # PyQt4 and PySide
-            QtTest.QTest.qWaitForWindowShown(widget)
+            qt_api.QtTest.QTest.qWaitForWindowShown(widget)
         else:  # pragma: no cover
             # PyQt5
-            QtTest.QTest.qWaitForWindowExposed(widget)
+            qt_api.QtTest.QTest.qWaitForWindowExposed(widget)
 
     wait_for_window_shown = waitForWindowShown  # pep-8 alias
 
@@ -227,7 +181,7 @@ class QtBot(object):
             if widget is not None:
                 widget_and_visibility.append((widget, widget.isVisible()))
 
-        QApplication.instance().exec_()
+        qt_api.QApplication.instance().exec_()
 
         for widget, visible in widget_and_visibility:
             widget.setVisible(visible)
@@ -442,6 +396,48 @@ class QtBot(object):
             self.wait(10)
 
     wait_until = waitUntil  # pep-8 alias
+
+    @classmethod
+    def _inject_qtest_methods(cls):
+        """
+        Injects QTest methods into the given class QtBot, so the user can access
+        them directly without having to import QTest.
+        """
+
+        def create_qtest_proxy_method(method_name):
+
+            if hasattr(qt_api.QtTest.QTest, method_name):
+                qtest_method = getattr(qt_api.QtTest.QTest, method_name)
+
+                def result(*args, **kwargs):
+                    return qtest_method(*args, **kwargs)
+
+                functools.update_wrapper(result, qtest_method)
+                return staticmethod(result)
+            else:
+                return None  # pragma: no cover
+
+        # inject methods from QTest into QtBot
+        method_names = [
+            'keyPress',
+            'keyClick',
+            'keyClicks',
+            'keyEvent',
+            'keyPress',
+            'keyRelease',
+            'keyToAscii',
+
+            'mouseClick',
+            'mouseDClick',
+            'mouseEvent',
+            'mouseMove',
+            'mousePress',
+            'mouseRelease',
+        ]
+        for method_name in method_names:
+            method = create_qtest_proxy_method(method_name)
+            if method is not None:
+                setattr(cls, method_name, method)
 
 
 # provide easy access to SignalTimeoutError to qtbot fixtures

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -1,5 +1,5 @@
 import functools
-from pytestqt.qt_compat import QtCore
+from pytestqt.qt_compat import qt_api
 
 
 class _AbstractSignalBlocker(object):
@@ -17,14 +17,14 @@ class _AbstractSignalBlocker(object):
     """
 
     def __init__(self, timeout=1000, raising=True):
-        self._loop = QtCore.QEventLoop()
+        self._loop = qt_api.QtCore.QEventLoop()
         self.timeout = timeout
         self.signal_triggered = False
         self.raising = raising
         if timeout is None:
             self._timer = None
         else:
-            self._timer = QtCore.QTimer(self._loop)
+            self._timer = qt_api.QtCore.QTimer(self._loop)
             self._timer.setSingleShot(True)
             self._timer.setInterval(timeout)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -12,21 +12,21 @@ def test_catch_exceptions_in_virtual_methods(testdir, raise_error):
     :type testdir: _pytest.pytester.TmpTestdir
     """
     testdir.makepyfile('''
-        from pytestqt.qt_compat import QtCore, QApplication
+        from pytestqt.qt_compat import qt_api
 
-        class Receiver(QtCore.QObject):
+        class Receiver(qt_api.QtCore.QObject):
 
             def event(self, ev):
                 if {raise_error}:
                     raise ValueError('mistakes were made')
-                return QtCore.QObject.event(self, ev)
+                return qt_api.QtCore.QObject.event(self, ev)
 
 
         def test_exceptions(qtbot):
             v = Receiver()
-            app = QApplication.instance()
-            app.sendEvent(v, QtCore.QEvent(QtCore.QEvent.User))
-            app.sendEvent(v, QtCore.QEvent(QtCore.QEvent.User))
+            app = qt_api.QApplication.instance()
+            app.sendEvent(v, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.User))
+            app.sendEvent(v, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.User))
             app.processEvents()
 
     '''.format(raise_error=raise_error))
@@ -74,7 +74,9 @@ def test_no_capture(testdir, no_capture_by_marker):
     testdir.makepyfile('''
         import pytest
         import sys
-        from pytestqt.qt_compat import QWidget, QtCore
+        from pytestqt.qt_compat import qt_api
+        QWidget = qt_api.QWidget
+        QtCore = qt_api.QtCore
 
         # PyQt 5.5+ will crash if there's no custom exception handler installed
         sys.excepthook = lambda *args: None
@@ -103,7 +105,9 @@ def test_no_capture_preserves_custom_excepthook(testdir):
     testdir.makepyfile('''
         import pytest
         import sys
-        from pytestqt.qt_compat import QWidget, QtCore
+        from pytestqt.qt_compat import qt_api
+        QWidget = qt_api.QWidget
+        QtCore = qt_api.QtCore
 
         def custom_excepthook(*args):
             sys.__excepthook__(*args)
@@ -129,7 +133,10 @@ def test_exception_capture_on_call(testdir):
     """
     testdir.makepyfile('''
         import pytest
-        from pytestqt.qt_compat import QWidget, QtCore, QEvent
+        from pytestqt.qt_compat import qt_api
+        QWidget = qt_api.QWidget
+        QtCore = qt_api.QtCore
+        QEvent = qt_api.QtCore.QEvent
 
         class MyWidget(QWidget):
 
@@ -156,7 +163,10 @@ def test_exception_capture_on_widget_close(testdir):
     """
     testdir.makepyfile('''
         import pytest
-        from pytestqt.qt_compat import QWidget, QtCore, QEvent
+        from pytestqt.qt_compat import qt_api
+        QWidget = qt_api.QWidget
+        QtCore = qt_api.QtCore
+        QEvent = qt_api.QtCore.QEvent
 
         class MyWidget(QWidget):
 
@@ -192,7 +202,11 @@ def test_exception_capture_on_fixture_setup_and_teardown(testdir, mode):
 
     testdir.makepyfile('''
         import pytest
-        from pytestqt.qt_compat import QWidget, QtCore, QEvent, QApplication
+        from pytestqt.qt_compat import qt_api
+        QWidget = qt_api.QWidget
+        QtCore = qt_api.QtCore
+        QEvent = qt_api.QtCore.QEvent
+        QApplication = qt_api.QApplication
 
         class MyWidget(QWidget):
 
@@ -230,17 +244,17 @@ def test_capture_exceptions_context_manager(qapp):
     While not used internally anymore, it is still part of the API and therefore
     should be properly tested.
     """
-    from pytestqt.qt_compat import QtCore
+    from pytestqt.qt_compat import qt_api
     from pytestqt.plugin import capture_exceptions
 
-    class Receiver(QtCore.QObject):
+    class Receiver(qt_api.QtCore.QObject):
 
         def event(self, ev):
             raise ValueError('mistakes were made')
 
     r = Receiver()
     with capture_exceptions() as exceptions:
-        qapp.sendEvent(r, QtCore.QEvent(QtCore.QEvent.User))
+        qapp.sendEvent(r, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.User))
         qapp.processEvents()
 
     assert [str(e) for (t, e, tb) in exceptions] == ['mistakes were made']
@@ -251,9 +265,9 @@ def test_exceptions_to_stderr(qapp, capsys):
     Exceptions should still be reported to stderr.
     """
     called = []
-    from pytestqt.qt_compat import QWidget, QEvent
+    from pytestqt.qt_compat import qt_api
 
-    class MyWidget(QWidget):
+    class MyWidget(qt_api.QWidget):
 
         def event(self, ev):
             called.append(1)
@@ -261,7 +275,7 @@ def test_exceptions_to_stderr(qapp, capsys):
 
     w = MyWidget()
     with capture_exceptions() as exceptions:
-        qapp.postEvent(w, QEvent(QEvent.User))
+        qapp.postEvent(w, qt_api.QEvent(qt_api.QEvent.User))
         qapp.processEvents()
     assert called
     del exceptions[:]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,8 +2,7 @@ import datetime
 
 import pytest
 
-from pytestqt.qt_compat import qDebug, qWarning, qCritical, QtDebugMsg, \
-    QtWarningMsg, QtCriticalMsg, QT_API
+from pytestqt.qt_compat import qt_api
 
 
 @pytest.mark.parametrize('test_succeeds', [True, False])
@@ -17,25 +16,24 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
     testdir.makepyfile(
         """
         import sys
-        from pytestqt.qt_compat import qDebug, qWarning, qCritical, \
-            qInstallMessageHandler, qInstallMsgHandler
+        from pytestqt.qt_compat import qt_api
 
         def to_unicode(s):
             return s.decode('utf-8', 'replace') if isinstance(s, bytes) else s
 
-        if qInstallMessageHandler:
+        if qt_api.qInstallMessageHandler:
             def print_msg(msg_type, context, message):
                 sys.stderr.write(to_unicode(message) + '\\n')
-            qInstallMessageHandler(print_msg)
+            qt_api.qInstallMessageHandler(print_msg)
         else:
             def print_msg(msg_type, message):
                 sys.stderr.write(to_unicode(message) + '\\n')
-            qInstallMsgHandler(print_msg)
+            qt_api.qInstallMsgHandler(print_msg)
 
         def test_types():
-            qDebug('this is a DEBUG message')
-            qWarning('this is a WARNING message')
-            qCritical('this is a CRITICAL message')
+            qt_api.qDebug('this is a DEBUG message')
+            qt_api.qWarning('this is a WARNING message')
+            qt_api.qCritical('this is a CRITICAL message')
             assert {0}
         """.format(test_succeeds)
     )
@@ -64,14 +62,14 @@ def test_qtlog_fixture(qtlog):
     """
     Test qtlog fixture.
     """
-    qDebug('this is a DEBUG message')
-    qWarning('this is a WARNING message')
-    qCritical('this is a CRITICAL message')
+    qt_api.qDebug('this is a DEBUG message')
+    qt_api.qWarning('this is a WARNING message')
+    qt_api.qCritical('this is a CRITICAL message')
     records = [(m.type, m.message.strip()) for m in qtlog.records]
     assert records == [
-        (QtDebugMsg, 'this is a DEBUG message'),
-        (QtWarningMsg, 'this is a WARNING message'),
-        (QtCriticalMsg, 'this is a CRITICAL message'),
+        (qt_api.QtDebugMsg, 'this is a DEBUG message'),
+        (qt_api.QtWarningMsg, 'this is a WARNING message'),
+        (qt_api.QtCriticalMsg, 'this is a CRITICAL message'),
     ]
     # `records` attribute is read-only
     with pytest.raises(AttributeError):
@@ -87,10 +85,10 @@ def test_fixture_with_logging_disabled(testdir):
     """
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning
+        from pytestqt.qt_compat import qt_api
 
         def test_types(qtlog):
-            qWarning('message')
+            qt_api.qWarning('message')
             assert qtlog.records == []
         """
     )
@@ -119,10 +117,10 @@ def test_disable_qtlog_context_manager(testdir, use_context_manager):
 
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qCritical
+        from pytestqt.qt_compat import qt_api
         def test_1(qtlog):
             {code}
-                qCritical('message')
+                qt_api.qCritical('message')
         """.format(code=code)
     )
     res = testdir.inline_run()
@@ -147,11 +145,11 @@ def test_disable_qtlog_mark(testdir, use_mark):
 
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qCritical
+        from pytestqt.qt_compat import qt_api
         import pytest
         {mark}
         def test_1():
-            qCritical('message')
+            qt_api.qCritical('message')
         """.format(mark=mark)
     )
     res = testdir.inline_run()
@@ -167,9 +165,9 @@ def test_logging_formatting(testdir):
     """
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning
+        from pytestqt.qt_compat import qt_api
         def test_types():
-            qWarning('this is a WARNING message')
+            qt_api.qWarning('this is a WARNING message')
             assert 0
         """
     )
@@ -200,13 +198,13 @@ def test_logging_fails_tests(testdir, level, expect_passes):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning, qCritical, qDebug
+        from pytestqt.qt_compat import qt_api
         def test_1():
-            qDebug('this is a DEBUG message')
+            qt_api.qDebug('this is a DEBUG message')
         def test_2():
-            qWarning('this is a WARNING message')
+            qt_api.qWarning('this is a WARNING message')
         def test_3():
-            qCritical('this is a CRITICAL message')
+            qt_api.qCritical('this is a CRITICAL message')
         def test_4():
             assert 1
         """
@@ -265,19 +263,19 @@ def test_logging_fails_ignore(testdir):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qCritical
+        from pytestqt.qt_compat import qt_api
         import pytest
 
         def test1():
-            qCritical('a critical message')
+            qt_api.qCritical('a critical message')
         def test2():
-            qCritical('WM_DESTROY was sent')
+            qt_api.qCritical('WM_DESTROY was sent')
         def test3():
-            qCritical('WM_DESTROY was sent')
+            qt_api.qCritical('WM_DESTROY was sent')
             assert 0
         def test4():
-            qCritical('WM_PAINT not handled')
-            qCritical('another critical message')
+            qt_api.qCritical('WM_PAINT not handled')
+            qt_api.qCritical('another critical message')
         """
     )
     res = testdir.runpytest()
@@ -328,12 +326,12 @@ def test_logging_mark_with_extend(testdir, message, marker_args):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qCritical
+        from pytestqt.qt_compat import qt_api
         import pytest
 
         @pytest.mark.qt_log_ignore({marker_args})
         def test1():
-            qCritical('{message}')
+            qt_api.qCritical('{message}')
         """.format(message=message, marker_args=marker_args)
     )
     res = testdir.inline_run()
@@ -359,12 +357,12 @@ def test_logging_mark_without_extend(testdir, message, error_expected):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qCritical
+        from pytestqt.qt_compat import qt_api
         import pytest
 
         @pytest.mark.qt_log_ignore('match-mark', extend=False)
         def test1():
-            qCritical('{message}')
+            qt_api.qCritical('{message}')
         """.format(message=message)
     )
     res = testdir.inline_run()
@@ -416,12 +414,12 @@ def test_logging_fails_ignore_mark_multiple(testdir, apply_mark):
         mark = ''
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qCritical
+        from pytestqt.qt_compat import qt_api
         import pytest
         @pytest.mark.qt_log_level_fail('CRITICAL')
         {mark}
         def test1():
-            qCritical('WM_PAINT was sent')
+            qt_api.qCritical('WM_PAINT was sent')
         """.format(mark=mark)
     )
     res = testdir.inline_run()
@@ -444,16 +442,16 @@ def test_lineno_failure(testdir):
     )
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import qWarning
+        from pytestqt.qt_compat import qt_api
         def test_foo():
             assert foo() == 10
         def foo():
-            qWarning('this is a WARNING message')
+            qt_api.qWarning('this is a WARNING message')
             return 10
         """
     )
     res = testdir.runpytest()
-    if QT_API == 'pyqt5':
+    if qt_api.pytest_qt_api == 'pyqt5':
         res.stdout.fnmatch_lines([
             '*test_lineno_failure.py:2: Failure*',
             '*test_lineno_failure.py:foo:5:*',
@@ -463,8 +461,6 @@ def test_lineno_failure(testdir):
         res.stdout.fnmatch_lines('*test_lineno_failure.py:2: Failure*')
 
 
-@pytest.mark.skipif(QT_API != 'pyqt5',
-                    reason='Context information only available in PyQt5')
 def test_context_none(testdir):
     """
     Sometimes PyQt5 will emit a context with some/all attributes set as None
@@ -474,14 +470,16 @@ def test_context_none(testdir):
 
     :type testdir: _pytest.pytester.TmpTestdir
     """
+    if qt_api.pytest_qt_api != 'pyqt5':
+        pytest.skip('Context information only available in PyQt5')
     testdir.makepyfile(
         """
-        from pytestqt.qt_compat import QtWarningMsg
+        from pytestqt.qt_compat import qt_api
 
         def test_foo(request):
             log_capture = request.node.qt_log_capture
             context = log_capture._Context(None, None, None)
-            log_capture._handle_with_context(QtWarningMsg,
+            log_capture._handle_with_context(qt_api.QtWarningMsg,
                                              context, "WARNING message")
             assert 0
         """

--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -1,38 +1,34 @@
-import os
-
 import pytest
 
-from pytestqt.qt_compat import QStandardItemModel, QStandardItem, \
-    QStringListModel, QSortFilterProxyModel, QT_API, QAbstractListModel, \
-    QtCore
+from pytestqt.qt_compat import qt_api
 
 pytestmark = pytest.mark.usefixtures('qtbot')
 
 
-class BasicModel(QtCore.QAbstractItemModel):
+class BasicModel(qt_api.QtCore.QAbstractItemModel):
 
-    def data(self, index, role=QtCore.Qt.DisplayRole):
+    def data(self, index, role=qt_api.QtCore.Qt.DisplayRole):
         return None
 
-    def rowCount(self, parent=QtCore.QModelIndex()):
+    def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
         return 0
 
-    def columnCount(self, parent=QtCore.QModelIndex()):
+    def columnCount(self, parent=qt_api.QtCore.QModelIndex()):
         return 0
 
-    def index(self, row, column, parent=QtCore.QModelIndex()):
-        return QtCore.QModelIndex()
+    def index(self, row, column, parent=qt_api.QtCore.QModelIndex()):
+        return qt_api.QtCore.QModelIndex()
 
     def parent(self, index):
-        return QtCore.QModelIndex()
+        return qt_api.QtCore.QModelIndex()
 
 
 def test_standard_item_model(qtmodeltester):
     """
-    Basic test which uses qtmodeltester with a QStandardItemModel.
+    Basic test which uses qtmodeltester with a qt_api.QStandardItemModel.
     """
-    model = QStandardItemModel()
-    items = [QStandardItem(str(i)) for i in range(6)]
+    model = qt_api.QStandardItemModel()
+    items = [qt_api.QStandardItem(str(i)) for i in range(6)]
     model.setItem(0, 0, items[0])
     model.setItem(0, 1, items[1])
     model.setItem(1, 0, items[2])
@@ -45,41 +41,41 @@ def test_standard_item_model(qtmodeltester):
 
 
 def test_string_list_model(qtmodeltester):
-    model = QStringListModel()
+    model = qt_api.QStringListModel()
     model.setStringList(['hello', 'world'])
     qtmodeltester.check(model)
 
 
 def test_sort_filter_proxy_model(qtmodeltester):
-    model = QStringListModel()
+    model = qt_api.QStringListModel()
     model.setStringList(['hello', 'world'])
-    proxy = QSortFilterProxyModel()
+    proxy = qt_api.QSortFilterProxyModel()
     proxy.setSourceModel(model)
     qtmodeltester.check(proxy)
 
 
 @pytest.mark.parametrize('broken_role', [
-    QtCore.Qt.ToolTipRole, QtCore.Qt.StatusTipRole,
-    QtCore.Qt.WhatsThisRole,
-    QtCore.Qt.SizeHintRole, QtCore.Qt.FontRole,
-    QtCore.Qt.BackgroundColorRole,
-    QtCore.Qt.TextColorRole, QtCore.Qt.TextAlignmentRole,
-    QtCore.Qt.CheckStateRole,
+    qt_api.QtCore.Qt.ToolTipRole, qt_api.QtCore.Qt.StatusTipRole,
+    qt_api.QtCore.Qt.WhatsThisRole,
+    qt_api.QtCore.Qt.SizeHintRole, qt_api.QtCore.Qt.FontRole,
+    qt_api.QtCore.Qt.BackgroundColorRole,
+    qt_api.QtCore.Qt.TextColorRole, qt_api.QtCore.Qt.TextAlignmentRole,
+    qt_api.QtCore.Qt.CheckStateRole,
 ])
 def test_broken_types(check_model, broken_role):
     """
     Check that qtmodeltester correctly captures data() returning invalid
     values for various display roles.
     """
-    class BrokenTypeModel(QAbstractListModel):
+    class BrokenTypeModel(qt_api.QAbstractListModel):
 
-        def rowCount(self, parent=QtCore.QModelIndex()):
-            if parent == QtCore.QModelIndex():
+        def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
+            if parent == qt_api.QtCore.QModelIndex():
                 return 1
             else:
                 return 0
 
-        def data(self, index=QtCore.QModelIndex(), role=QtCore.Qt.DisplayRole):
+        def data(self, index=qt_api.QtCore.QModelIndex(), role=qt_api.QtCore.Qt.DisplayRole):
             if role == broken_role:
                 return object()  # This will fail the type check for any role
             else:
@@ -89,8 +85,8 @@ def test_broken_types(check_model, broken_role):
 
 
 @pytest.mark.parametrize('role_value, should_pass', [
-    (QtCore.Qt.AlignLeft, True),
-    (QtCore.Qt.AlignRight, True),
+    (qt_api.QtCore.Qt.AlignLeft, True),
+    (qt_api.QtCore.Qt.AlignRight, True),
     (0xFFFFFF, False),
     ('foo', False),
     (object(), False),
@@ -99,15 +95,15 @@ def test_data_alignment(role_value, should_pass, check_model):
     """Test a custom model which returns a good and alignments from data().
     qtmodeltest should capture this problem and fail when that happens.
     """
-    class MyModel(QAbstractListModel):
+    class MyModel(qt_api.QAbstractListModel):
 
-        def rowCount(self, parent=QtCore.QModelIndex()):
-            return 1 if parent == QtCore.QModelIndex() else 0
+        def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
+            return 1 if parent == qt_api.QtCore.QModelIndex() else 0
 
-        def data(self, index=QtCore.QModelIndex(), role=QtCore.Qt.DisplayRole):
-            if role == QtCore.Qt.TextAlignmentRole:
+        def data(self, index=qt_api.QtCore.QModelIndex(), role=qt_api.QtCore.Qt.DisplayRole):
+            if role == qt_api.QtCore.Qt.TextAlignmentRole:
                 return role_value
-            elif role == QtCore.Qt.DisplayRole:
+            elif role == qt_api.QtCore.Qt.DisplayRole:
                 if index == self.index(0, 0):
                     return 'Hello'
             return None
@@ -117,21 +113,21 @@ def test_data_alignment(role_value, should_pass, check_model):
 
 def test_header_handling(check_model):
 
-    class MyModel(QAbstractListModel):
+    class MyModel(qt_api.QAbstractListModel):
 
-        def rowCount(self, parent=QtCore.QModelIndex()):
-            return 1 if parent == QtCore.QModelIndex() else 0
+        def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
+            return 1 if parent == qt_api.QtCore.QModelIndex() else 0
 
         def set_header_text(self, header):
             self._header_text = header
-            self.headerDataChanged.emit(QtCore.Qt.Vertical, 0, 0)
-            self.headerDataChanged.emit(QtCore.Qt.Horizontal, 0, 0)
+            self.headerDataChanged.emit(qt_api.QtCore.Qt.Vertical, 0, 0)
+            self.headerDataChanged.emit(qt_api.QtCore.Qt.Horizontal, 0, 0)
 
-        def headerData(self, section, orientation, role=QtCore.Qt.DisplayRole):
+        def headerData(self, section, orientation, role=qt_api.QtCore.Qt.DisplayRole):
             return self._header_text
 
-        def data(self, index=QtCore.QModelIndex(), role=QtCore.Qt.DisplayRole):
-            if role == QtCore.Qt.DisplayRole and index == self.index(0, 0):
+        def data(self, index=qt_api.QtCore.QModelIndex(), role=qt_api.QtCore.Qt.DisplayRole):
+            if role == qt_api.QtCore.Qt.DisplayRole and index == self.index(0, 0):
                 return 'Contents'
             return None
 
@@ -160,7 +156,7 @@ def check_model(qtmodeltester):
 def test_invalid_column_count(qtmodeltester):
     """Basic check with an invalid model."""
     class Model(BasicModel):
-        def columnCount(self, parent=QtCore.QModelIndex()):
+        def columnCount(self, parent=qt_api.QtCore.QModelIndex()):
             return -1
 
     model = Model()
@@ -170,33 +166,33 @@ def test_invalid_column_count(qtmodeltester):
 
 
 def test_changing_model_insert(qtmodeltester):
-    model = QStandardItemModel()
-    item = QStandardItem('foo')
+    model = qt_api.QStandardItemModel()
+    item = qt_api.QStandardItem('foo')
     qtmodeltester.check(model)
     model.insertRow(0, item)
 
 
 def test_changing_model_remove(qtmodeltester):
-    model = QStandardItemModel()
-    item = QStandardItem('foo')
+    model = qt_api.QStandardItemModel()
+    item = qt_api.QStandardItem('foo')
     model.setItem(0, 0, item)
     qtmodeltester.check(model)
     model.removeRow(0)
 
 
 def test_changing_model_data(qtmodeltester):
-    model = QStandardItemModel()
-    item = QStandardItem('foo')
+    model = qt_api.QStandardItemModel()
+    item = qt_api.QStandardItem('foo')
     model.setItem(0, 0, item)
     qtmodeltester.check(model)
     model.setData(model.index(0, 0), 'hello world')
 
 
-@pytest.mark.parametrize('orientation', [QtCore.Qt.Horizontal,
-                                         QtCore.Qt.Vertical])
+@pytest.mark.parametrize('orientation', [qt_api.QtCore.Qt.Horizontal,
+                                         qt_api.QtCore.Qt.Vertical])
 def test_changing_model_header_data(qtmodeltester, orientation):
-    model = QStandardItemModel()
-    item = QStandardItem('foo')
+    model = qt_api.QStandardItemModel()
+    item = qt_api.QStandardItem('foo')
     model.setItem(0, 0, item)
     qtmodeltester.check(model)
     model.setHeaderData(0, orientation, 'blah')
@@ -204,8 +200,8 @@ def test_changing_model_header_data(qtmodeltester, orientation):
 
 def test_changing_model_sort(qtmodeltester):
     """Sorting emits layoutChanged"""
-    model = QStandardItemModel()
-    item = QStandardItem('foo')
+    model = qt_api.QStandardItemModel()
+    item = qt_api.QStandardItem('foo')
     model.setItem(0, 0, item)
     qtmodeltester.check(model)
     model.sort(0)
@@ -239,7 +235,7 @@ def test_overridden_methods(qtmodeltester):
 
 
 def test_fetch_more(qtmodeltester):
-    class Model(QStandardItemModel):
+    class Model(qt_api.QStandardItemModel):
 
         def canFetchMore(self, parent):
             return True
@@ -249,25 +245,25 @@ def test_fetch_more(qtmodeltester):
             self.setData(self.index(0, 0), 'bar')
 
     model = Model()
-    item = QStandardItem('foo')
+    item = qt_api.QStandardItem('foo')
     model.setItem(0, 0, item)
     qtmodeltester.check(model)
 
 
 def test_invalid_parent(qtmodeltester):
 
-    class Model(QStandardItemModel):
+    class Model(qt_api.QStandardItemModel):
 
         def parent(self, index):
             if index == self.index(0, 0, parent=self.index(0, 0)):
                 return self.index(0, 0)
             else:
-                return QtCore.QModelIndex()
+                return qt_api.QtCore.QModelIndex()
 
     model = Model()
-    item = QStandardItem('foo')
-    item2 = QStandardItem('bar')
-    item3 = QStandardItem('bar')
+    item = qt_api.QStandardItem('foo')
+    item2 = qt_api.QStandardItem('bar')
+    item3 = qt_api.QStandardItem('bar')
     model.setItem(0, 0, item)
     item.setChild(0, item2)
     item2.setChild(0, item3)

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -1,10 +1,10 @@
 import pytest
 
-from pytestqt.qt_compat import USING_PYSIDE
+# noinspection PyUnresolvedReferences
+from pytestqt.qt_compat import qt_api
 
 
-fails_on_pyqt = pytest.mark.xfail(not USING_PYSIDE,
-                                  reason='not exported by PyQt')
+fails_on_pyqt = pytest.mark.xfail('qt_api.pytest_qt_api != "pyside"')
 
 
 @pytest.mark.parametrize('expected_method', [

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -317,6 +317,11 @@ def test_wait_twice(qtbot, timer, multiple, do_timeout, signaller):
             signaller.signal.emit()
 
 
+def test_wait_signals_invalid_strict_parameter(qtbot, signaller):
+    with pytest.raises(ValueError):
+        qtbot.waitSignals([signaller.signal], order='invalid')
+
+
 def test_destroyed(qtbot):
     """Test that waitSignal works with the destroyed signal (#82).
 

--- a/tests/test_wait_until.py
+++ b/tests/test_wait_until.py
@@ -41,13 +41,13 @@ def tick_counter():
     """
     Returns an object which counts timer "ticks" periodically.
     """
-    from pytestqt.qt_compat import QtCore
+    from pytestqt.qt_compat import qt_api
 
     class Counter:
 
         def __init__(self):
             self._ticks = 0
-            self.timer = QtCore.QTimer()
+            self.timer = qt_api.QtCore.QTimer()
             self.timer.timeout.connect(self._tick)
 
         def start(self, ms):


### PR DESCRIPTION
Fix #129

The big work here was of course to implement lazy-loading of Qt classes from `qt_compat`.