### PR TITLE
Supported python versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
 - ``pytest-qt`` now defaults to using ``PyQt5`` if ``PYTEST_QT_API`` is not set.
   Before, it preferred ``PySide`` which is using the discontinued Qt4.
 
+- Python 3 versions prior to 3.4 are no longer supported.
+
 - Exceptions caught by ``pytest-qt`` in ``sys.excepthook`` are now also printed
   to ``stderr``, making debugging them easier from within an IDE.
   Thanks `@fabioz`_ for the PR (`126`_)!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,16 @@ environment:
     - INSTALL_QT: "py34-pyqt5"
       TESTENVS: "py34-pyqt5"
 
+    - INSTALL_QT: "py35-pyqt5"
+      TESTENVS: "py35-pyqt5"
+
     - INSTALL_QT: "py34-pyqt4"
       TESTENVS: "py34-pyqt4"
 
     - INSTALL_QT: "py27-pyqt4"
       TESTENVS: "py27-pyqt4"
 
-    - TESTENVS: "py27-pyside,py33-pyside,py34-pyside,docs"
+    - TESTENVS: "py27-pyside,py34-pyside,docs"
 
 install:
   - C:\Python27\python -u scripts\install-qt.py

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -26,7 +26,7 @@ interaction, like key presses and mouse clicks::
 Requirements
 ------------
 
-Python 2.7 or later, including Python 3+.
+Python 2.7 or later, including Python 3.4+.
 
 Requires pytest version 2.7 or later.
 

--- a/scripts/install-qt.py
+++ b/scripts/install-qt.py
@@ -27,11 +27,13 @@ if 'APPVEYOR' in os.environ:
     base_url = 'http://downloads.sourceforge.net/project/pyqt/'
     downloads = {
         'py34-pyqt5': 'PyQt5/PyQt-5.5/PyQt5-5.5-gpl-Py3.4-Qt5.5.0-x32.exe',
+        'py35-pyqt5': 'PyQt5/PyQt-5.6/PyQt5-5.6-gpl-Py3.5-Qt5.6.0-x32-2.exe',
         'py34-pyqt4': 'PyQt4/PyQt-4.11.4/PyQt4-4.11.4-gpl-Py3.4-Qt4.8.7-x32.exe',
         'py27-pyqt4': 'PyQt4/PyQt-4.11.4/PyQt4-4.11.4-gpl-Py2.7-Qt4.8.7-x32.exe',
     }
     if 'INSTALL_QT' in os.environ:
         fix_registry('34')
+        fix_registry('35')
         fix_registry('27')
         caption = os.environ['INSTALL_QT']
         url = downloads[caption]

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Desktop Environment :: Window Managers',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # note that tox expects interpreters to be found at C:\PythonXY,
 # with XY being python version ("27" or "34") for instance
-envlist = py{27,34}-pyqt4, py34-pyqt5, py{26,27,33,34}-pyside, docs
+envlist = py{27,34}-pyqt4, py{34,35}-pyqt5, py{26,27,34,35}-pyside, docs
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
- Python 3.5 is now tested
- Python 3.3 is not tested anymore
- PyQt 5.6 is tested with Python 3.5