### PR TITLE
Small fix example in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ like key presses and mouse clicks:
         qtbot.addWidget(widget)
     
         # click in the Greet button and make sure it updates the appropriate label
-        qtbot.mouseClick(window.button_greet, QtCore.Qt.LeftButton)
+        qtbot.mouseClick(widget.button_greet, QtCore.Qt.LeftButton)
     
-        assert window.greet_label.text() == 'Hello!'
+        assert widget.greet_label.text() == 'Hello!'
 
 
 .. _PySide: https://pypi.python.org/pypi/PySide


### PR DESCRIPTION
Just fix variable name to widget. Tested using this HelloWidget class:

```
from PyQt4 import QtCore, QtGui


class HelloWidget(QtGui.QWidget):
    def __init__(self, parent=None):
        QtGui.QWidget.__init__(self, parent)

        self.button_greet = QtGui.QPushButton()
        self.greet_label = QtGui.QLabel()
        self.connect(self.button_greet, QtCore.SIGNAL('clicked()'),
                     self, QtCore.SLOT('set_text()'))

    @QtCore.pyqtSlot()
    def set_text(self):
        self.greet_label.setText('Hello!')


def test_hello(qtbot):
    widget = HelloWidget()
    qtbot.addWidget(widget)

    # click in the Greet button and make sure it updates the appropriate label
    qtbot.mouseClick(widget.button_greet, QtCore.Qt.LeftButton)

    assert widget.greet_label.text() == 'Hello!'
```