### PR TITLE
Support for capturing signals and args and improved SignalTimeoutError messages

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -114,6 +114,16 @@ of the blocker:
 Signals without arguments will set ``args`` to an empty list. If the time out
 is reached instead, ``args`` will be ``None``.
 
+Getting all arguments of non-matching arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.0
+
+When using the ``check_params_cb`` parameter, it may happen that the provided signal is received multiple times with
+different parameter values, which may or may not match the requirements of the callback.
+``all_args`` then contains the list of signal parameters (as tuple) in the order they were received.
+
+
 waitSignals
 -----------
 
@@ -174,7 +184,7 @@ evaluation takes place).
 
 
 order parameter
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 
 .. versionadded:: 2.0
 
@@ -193,6 +203,17 @@ the signals ``[a, b]`` but the sender emitted signals ``[a, a, b]``.
 A third option is to set ``order="simple"`` which is like "strict", but signals may be emitted
 in-between the provided ones, e.g. if the expected signals are ``[a, b, c]`` and the sender 
 actually emits ``[a, a, b, a, c]``, the test completes successfully (it would fail with ``order="strict"``).
+
+Getting emitted signals and arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.1
+
+To determine which of the expected signals were emitted during a ``wait()`` you can use
+``blocker.all_signals_and_args`` which contains a list of
+:class:`wait_signal.SignalAndArgs <SignalAndArgs>` ``namedtuple`` objects, indicating the signals (and their arguments)
+in the order they were received.
+
 
 Making sure a given signal is not emitted
 -----------------------------------------

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -211,7 +211,7 @@ Getting emitted signals and arguments
 
 To determine which of the expected signals were emitted during a ``wait()`` you can use
 ``blocker.all_signals_and_args`` which contains a list of
-:class:`wait_signal.SignalAndArgs <SignalAndArgs>` ``namedtuple`` objects, indicating the signals (and their arguments)
+:class:`wait_signal.SignalAndArgs <SignalAndArgs>` objects, indicating the signals (and their arguments)
 in the order they were received.
 
 

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -117,7 +117,7 @@ is reached instead, ``args`` will be ``None``.
 Getting all arguments of non-matching arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 2.0
+.. versionadded:: 2.1
 
 When using the ``check_params_cb`` parameter, it may happen that the provided signal is received multiple times with
 different parameter values, which may or may not match the requirements of the callback.

--- a/pytestqt/qtbot.py
+++ b/pytestqt/qtbot.py
@@ -215,8 +215,12 @@ class QtBot(object):
         .. versionadded:: 1.4
            The *raising* parameter.
 
+        .. versionadded:: 2.0
+           The *check_params_cb* parameter.
+
         :param Signal signal:
-            A signal to wait for. Set to ``None`` to just use timeout.
+            A signal to wait for, or a tuple (signal, signal_name_as_str) to improve the error message that is part
+            of ``SignalTimeoutError``. Set to ``None`` to just use timeout.
         :param int timeout:
             How many milliseconds to wait before resuming control flow.
         :param bool raising:
@@ -225,7 +229,7 @@ class QtBot(object):
             This defaults to ``True`` unless ``qt_wait_signal_raising = false``
             is set in the config.
         :param Callable check_params_cb:
-            Optional ``callable(*parameters)`` that compares the provided signal parameters to some expected parameters.
+            Optional ``callable`` that compares the provided signal parameters to some expected parameters.
             It has to match the signature of ``signal`` (just like a slot function would) and return ``True`` if
             parameters match, ``False`` otherwise.
         :returns:
@@ -274,8 +278,9 @@ class QtBot(object):
            blocker.wait()
 
         :param list signals:
-            A list of :class:`Signal` objects to wait for. Set to ``None`` to just use
-            timeout.
+            A list of :class:`Signal` objects to wait for. Alternatively: a list of (``Signal, str``) tuples of the form
+            ``(signal, signal_name_as_str)`` to improve the error message that is part of ``SignalTimeoutError``.
+            Set to ``None`` to just use timeout.
         :param int timeout:
             How many milliseconds to wait before resuming control flow.
         :param bool raising:

--- a/pytestqt/qtbot.py
+++ b/pytestqt/qtbot.py
@@ -219,7 +219,7 @@ class QtBot(object):
            The *check_params_cb* parameter.
 
         :param Signal signal:
-            A signal to wait for, or a tuple (signal, signal_name_as_str) to improve the error message that is part
+            A signal to wait for, or a tuple ``(signal, signal_name_as_str)`` to improve the error message that is part
             of ``SignalTimeoutError``. Set to ``None`` to just use timeout.
         :param int timeout:
             How many milliseconds to wait before resuming control flow.

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -227,11 +227,11 @@ class SignalBlocker(_AbstractSignalBlocker):
 
     def get_timeout_error_message(self):
         if self.check_params_callback is not None:
-            return "Signal {signal_name} emitted with parameters {params} " \
-                   "within {timeout} ms, but did not satisfy " \
-                   "the {cb_name} callback".format(signal_name=self.signal_name, params=self.get_params_as_str(),
-                                                   timeout=self.timeout,
-                                                   cb_name=self.get_callback_name(self.check_params_callback))
+            return ("Signal {signal_name} emitted with parameters {params} "
+                    "within {timeout} ms, but did not satisfy "
+                    "the {cb_name} callback").format(signal_name=self.signal_name, params=self.get_params_as_str(),
+                                                     timeout=self.timeout,
+                                                     cb_name=self.get_callback_name(self.check_params_callback))
         else:
             return "Signal {signal_name} not emitted after {timeout} ms".format(signal_name=self.signal_name,
                                                                                 timeout=self.timeout)
@@ -253,9 +253,6 @@ class SignalAndArgs:
         return signal_name + args
 
     def __str__(self):
-        return self._get_readable_signal_with_optional_args()
-
-    def __repr__(self):
         return self._get_readable_signal_with_optional_args()
 
     def __eq__(self, other):
@@ -452,9 +449,9 @@ class MultiSignalBlocker(_AbstractSignalBlocker):
     def _get_degenerate_error_message(self):
         received_signals = sum(self._signals_emitted)
         total_signals = len(self._signals_emitted)
-        return "Received {actual} of the {total} expected signals. " \
-               "To improve this error message, provide the names of the signals " \
-               "in the waitSignals() call.".format(actual=received_signals, total=total_signals)
+        return ("Received {actual} of the {total} expected signals. "
+                "To improve this error message, provide the names of the signals "
+                "in the waitSignals() call.").format(actual=received_signals, total=total_signals)
 
     def _get_expected_and_actual_signals_message(self):
         if not self.all_signals_and_args:
@@ -477,8 +474,8 @@ class MultiSignalBlocker(_AbstractSignalBlocker):
     def _get_order_violation_message(self):
         expected_signal_as_str = self._get_signal_string_representation_for_index(self._signal_expected_index)
         actual_signal_as_str = str(self._actual_signal_and_args_at_violation)
-        return "Signal order violated! Expected {expected} as {ordinal} signal, " \
-               "but received {actual} instead. ".format(expected=expected_signal_as_str,
+        return ("Signal order violated! Expected {expected} as {ordinal} signal, "
+               "but received {actual} instead. ").format(expected=expected_signal_as_str,
                                                         ordinal=get_ordinal_str(self._signal_expected_index + 1),
                                                         actual=actual_signal_as_str)
 

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -1,4 +1,6 @@
 import functools
+from collections import namedtuple
+
 from pytestqt.qt_compat import qt_api
 
 
@@ -21,6 +23,7 @@ class _AbstractSignalBlocker(object):
         self.signal_triggered = False
         self.raising = raising
         self._signals = None  # will be initialized by inheriting implementations
+        self._timeout_message = ""
         if timeout is None:
             self._timer = None
         else:
@@ -46,7 +49,7 @@ class _AbstractSignalBlocker(object):
         self._loop.exec_()
         if not self.signal_triggered and self.raising:
             # raise SignalTimeoutError("Didn't get signal after %sms." % self.timeout)
-            raise SignalTimeoutError(self.get_timeout_error_message())
+            raise SignalTimeoutError(self._timeout_message)
 
     def _quit_loop_by_timeout(self):
         try:
@@ -55,6 +58,8 @@ class _AbstractSignalBlocker(object):
             self._loop.quit()
 
     def _cleanup(self):
+        # store timeout message before the data to construct it is lost
+        self._timeout_message = self.get_timeout_error_message()
         if self._timer is not None:
             _silent_disconnect(self._timer.timeout, self._quit_loop_by_timeout)
             self._timer.stop()
@@ -80,15 +85,15 @@ class _AbstractSignalBlocker(object):
                                      "the second element is the signal's name).")
             signal_tuple = potential_signal_tuple
             signal_name = signal_tuple[1]
-            if type(signal_tuple) != str or not signal_name:
+            if type(signal_name) != str or not signal_name:
                 raise TypeError("Invalid type for user-provided signal name, "
                                 "expected str but got {}".format(type(signal_name)))
             return signal_name
         return ""
 
-    def get_signal_name(self, potential_signal_tuple):
+    def determine_signal_name(self, potential_signal_tuple):
         """
-        Attempts to extract the signal's name. If the user provided the signal name as 2nd value of the tuple, this
+        Attempts to determine the signal's name. If the user provided the signal name as 2nd value of the tuple, this
         name has preference. Bad values cause a ``ValueError``.
         Otherwise it attempts to get the signal from the ``signal`` attribute of ``signal`` (which only exists for
         PyQt signals).
@@ -117,6 +122,12 @@ class _AbstractSignalBlocker(object):
             except AttributeError:
                 name = ""
         return name
+
+    @staticmethod
+    def get_signal_from_potential_signal_tuple(signal_tuple):
+        if type(signal_tuple) is tuple:
+            return signal_tuple[0]
+        return signal_tuple
 
     def __enter__(self):
         return self
@@ -174,11 +185,12 @@ class SignalBlocker(_AbstractSignalBlocker):
         More than one signal can be connected, in which case **any** one of
         them will make ``wait()`` return.
 
-        :param signal: QtCore.Signal
+        :param signal: QtCore.Signal or tuple (QtCore.Signal, str)
         """
-        self.signal_name = self.get_signal_name(potential_signal_tuple=signal)
-        signal.connect(self._quit_loop_by_signal)
-        self._signals.append(signal)
+        self.signal_name = self.determine_signal_name(potential_signal_tuple=signal)
+        actual_signal = self.get_signal_from_potential_signal_tuple(signal)
+        actual_signal.connect(self._quit_loop_by_signal)
+        self._signals.append(actual_signal)
 
     def _quit_loop_by_signal(self, *args):
         """
@@ -216,15 +228,47 @@ class SignalBlocker(_AbstractSignalBlocker):
         return str(args_list)
 
     def get_timeout_error_message(self):
-        if self.check_params_callback:
+        if self.check_params_callback is not None:
             return "Signal {signal_name} emitted with parameters {params} " \
                    "within {timeout} ms, but did not satisfy " \
                    "the {cb_name} callback".format(signal_name=self.signal_name, params=self.get_params_as_str(),
                                                    timeout=self.timeout,
                                                    cb_name=self.get_callback_name(self.check_params_callback))
         else:
-            return "Signal{signal_name} not emitted after {timeout} ms".format(signal_name=self.signal_name,
+            return "Signal {signal_name} not emitted after {timeout} ms".format(signal_name=self.signal_name,
                                                                                timeout=self.timeout)
+
+
+SignalAndArgs = namedtuple("SignalAndArgs", ["signal_name", "args"])
+
+
+def _get_readable_signal_with_optional_args(self):
+    if self.args:
+        args_as_string = []
+        for arg in self.args:
+            if type(arg) is str:
+                args_as_string.append("'" + str(arg) + "'")
+            else:
+                args_as_string.append(str(arg))
+        args_as_list_string = ", ".join(args_as_string) if len(args_as_string) > 1 else args_as_string[0]
+        args = "({})".format(args_as_list_string)
+    else:
+        args = ""
+
+    # remove signal parameter signature, e.g. turn "some_signal(QString,int)" to "some_signal", because we're adding
+    # the actual parameters anyways
+    signal_name = self.signal_name
+    if '(' in signal_name:
+        signal_name = signal_name[:signal_name.index('(')]
+
+    return signal_name + args
+
+
+SignalAndArgs.__str__ = _get_readable_signal_with_optional_args
+SignalAndArgs.__repr__ = _get_readable_signal_with_optional_args
+
+# Returns e.g. "3rd" for 3, or "21st" for 21
+get_ordinal_str = lambda n: "%d%s" % (n, {1: "st", 2: "nd", 3: "rd"}.get(n if n < 20 else n % 10, "th"))
 
 
 class MultiSignalBlocker(_AbstractSignalBlocker):
@@ -242,106 +286,224 @@ class MultiSignalBlocker(_AbstractSignalBlocker):
 
     def __init__(self, timeout=1000, raising=True, check_params_cbs=None, order="none"):
         super(MultiSignalBlocker, self).__init__(timeout, raising=raising)
-        self.order = order
-        self.check_params_callbacks = check_params_cbs
+        self._order = order
+        self._check_params_callbacks = check_params_cbs
         self._signals_emitted = []  # list of booleans, indicates whether the signal was already emitted
         self._signals_map = {}  # maps from a unique Signal to a list of indices where to expect signal instance emits
         self._signals = []  # list of all Signals (for compatibility with _AbstractSignalBlocker)
         self._slots = []  # list of slot functions
         self._signal_expected_index = 0  # only used when forcing order
         self._strict_order_violated = False
+        self._actual_signal_and_args_at_violation = None
+        self._signal_names = {}  # maps from the unique Signal to the name of the signal (as string)
+        self.all_signals_and_args = []  # list of SignalAndArgs instances
 
     def add_signals(self, signals):
         """
         Adds the given signal to the list of signals which :meth:`wait()` waits
         for.
 
-        :param list signals: list of QtCore.Signal`s
+        :param list signals: list of QtCore.Signal`s or tuples (QtCore.Signal, str)
         """
-        # determine uniqueness of signals, creating a map that maps from a unique signal to a list of indices
+        self._determine_unique_signals(signals)
+        self._create_signal_emitted_indices(signals)
+        self._connect_unique_signals()
+
+    def get_timeout_error_message(self):
+        if not self._are_signal_names_available():
+            error_message = self._get_degenerate_error_message()
+        else:
+            error_message = self._get_expected_and_actual_signals_message()
+            if self._strict_order_violated:
+                error_message = self._get_order_violation_message() + error_message
+
+        return error_message
+
+    def _determine_unique_signals(self, signals):
+        # create a map that maps from a unique signal to a list of indices
         # (positions) where this signal is expected (in case order matters)
-        signals_as_str = [str(signal) for signal in signals]
-        signal_str_to_signal = {}  # maps from a signal-string to one of the signal instances (the first one found)
+        signals_as_str = [str(self.get_signal_from_potential_signal_tuple(signal)) for signal in signals]
+        signal_str_to_unique_signal = {}  # maps from a signal-string to one of the signal instances (the first one found)
         for index, signal_str in enumerate(signals_as_str):
-            signal = signals[index]
-            if signal_str not in signal_str_to_signal:
-                signal_str_to_signal[signal_str] = signal
+            signal = self.get_signal_from_potential_signal_tuple(signals[index])
+            potential_tuple = signals[index]
+            if signal_str not in signal_str_to_unique_signal:
+                unique_signal_tuple = potential_tuple
+                signal_str_to_unique_signal[signal_str] = signal
                 self._signals_map[signal] = [index]  # create a new list
             else:
                 # append to existing list
-                first_signal_that_occurred = signal_str_to_signal[signal_str]
-                self._signals_map[first_signal_that_occurred].append(index)
+                unique_signal = signal_str_to_unique_signal[signal_str]
+                self._signals_map[unique_signal].append(index)
+                unique_signal_tuple = signals[index]
 
+            self._determine_and_save_signal_name(unique_signal_tuple)
+
+    def _determine_and_save_signal_name(self, unique_signal_tuple):
+        signal_name = self.determine_signal_name(unique_signal_tuple)
+        if signal_name:  # might be an empty string if no name could be determined
+            unique_signal = self.get_signal_from_potential_signal_tuple(unique_signal_tuple)
+            self._signal_names[unique_signal] = signal_name
+
+    def _create_signal_emitted_indices(self, signals):
         for signal in signals:
             self._signals_emitted.append(False)
 
+    def _connect_unique_signals(self):
         for unique_signal in self._signals_map:
-            slot = functools.partial(self._signal_emitted, unique_signal)
+            slot = functools.partial(self._unique_signal_emitted, unique_signal)
             self._slots.append(slot)
             unique_signal.connect(slot)
             self._signals.append(unique_signal)
 
-    def _signal_emitted(self, signal, *args):
+    def _unique_signal_emitted(self, unique_signal, *args):
         """
         Called when a given signal is emitted.
 
         If all expected signals have been emitted, quits the event loop and
         marks that we finished because signals.
         """
-        if self.order == "none":
-            # perform the test for every matching index (stop after the first one that matches)
-            successfully_emitted = False
-            successful_index = -1
-            potential_indices = self._get_unemitted_signal_indices(signal)
-            for potential_index in potential_indices:
-                if self._check_callback(potential_index, *args):
-                    successful_index = potential_index
-                    successfully_emitted = True
-                    break
+        self._record_emitted_signal_if_possible(unique_signal, *args)
 
-            if successfully_emitted:
-                self._signals_emitted[successful_index] = True
-        elif self.order == "simple":
-            potential_indices = self._get_unemitted_signal_indices(signal)
-            if potential_indices:
-                if self._signal_expected_index == potential_indices[0]:
-                    if self._check_callback(self._signal_expected_index, *args):
-                        self._signals_emitted[self._signal_expected_index] = True
-                        self._signal_expected_index += 1
-        else:  # self.order == "strict"
-            if not self._strict_order_violated:
-                # only do the check if the strict order has not been violated yet
-                self._strict_order_violated = True  # assume the order has been violated this time
-                potential_indices = self._get_unemitted_signal_indices(signal)
-                if potential_indices:
-                    if self._signal_expected_index == potential_indices[0]:
-                        if self._check_callback(self._signal_expected_index, *args):
-                            self._signals_emitted[self._signal_expected_index] = True
-                            self._signal_expected_index += 1
-                            self._strict_order_violated = False  # order has not been violated after all!
+        self._check_signal_match(unique_signal, *args)
 
-        if not self._strict_order_violated and all(self._signals_emitted):
+        if self._all_signals_emitted():
+            self.signal_triggered = True
             try:
-                self.signal_triggered = True
                 self._cleanup()
             finally:
                 self._loop.quit()
 
-    def _check_callback(self, index, *args):
+    def _record_emitted_signal_if_possible(self, unique_signal, *args):
+        if self._are_signal_names_available():
+            self.all_signals_and_args.append(
+                SignalAndArgs(signal_name=self._signal_names[unique_signal], args=args))
+
+    def _check_signal_match(self, unique_signal, *args):
+        if self._order == "none":
+            # perform the test for every matching index (stop after the first one that matches)
+            try:
+                successful_index = self._get_first_matching_index(unique_signal, *args)
+                self._signals_emitted[successful_index] = True
+            except:  # none found
+                pass
+        elif self._order == "simple":
+            if self._check_signal_matches_expected_index(unique_signal, *args):
+                self._signals_emitted[self._signal_expected_index] = True
+                self._signal_expected_index += 1
+        else:  # self.order == "strict"
+            if not self._strict_order_violated:
+                # only do the check if the strict order has not been violated yet
+                self._strict_order_violated = True  # assume the order has been violated this time
+                if self._check_signal_matches_expected_index(unique_signal, *args):
+                    self._signals_emitted[self._signal_expected_index] = True
+                    self._signal_expected_index += 1
+                    self._strict_order_violated = False  # order has not been violated after all!
+                else:
+                    self._actual_signal_and_args_at_violation = SignalAndArgs(
+                        signal_name=self._signal_names[unique_signal], args=args)
+
+    def _all_signals_emitted(self):
+        return not self._strict_order_violated and all(self._signals_emitted)
+
+    def _get_first_matching_index(self, unique_signal, *args):
+        successfully_emitted = False
+        successful_index = -1
+        potential_indices = self._get_unemitted_signal_indices(unique_signal)
+        for potential_index in potential_indices:
+            if not self._violates_callback_at_index(potential_index, *args):
+                successful_index = potential_index
+                successfully_emitted = True
+                break
+        if not successfully_emitted:
+            raise Exception("No matching index was found")
+
+        return successful_index
+
+    def _check_signal_matches_expected_index(self, unique_signal, *args):
+        potential_indices = self._get_unemitted_signal_indices(unique_signal)
+        if potential_indices:
+            if self._signal_expected_index == potential_indices[0]:
+                if not self._violates_callback_at_index(self._signal_expected_index, *args):
+                    return True
+        return False
+
+    def _violates_callback_at_index(self, index, *args):
         """
-        Checks if there's a callback that evaluates the validity of the parameters. Returns False if there is one
-        and its evaluation revealed that the parameters were invalid. Returns True otherwise.
+        Checks if there's a callback at the provided index that is violates due to invalid parameters. Returns False if
+        there is no callback for that index, or if a callback exists but it wasn't violated (returned True).
+        Returns True otherwise.
         """
-        if self.check_params_callbacks:
-            callback_func = self.check_params_callbacks[index]
+        if self._check_params_callbacks:
+            callback_func = self._check_params_callbacks[index]
             if callback_func:
                 if not callback_func(*args):
-                    return False
-        return True
+                    return True
+        return False
 
     def _get_unemitted_signal_indices(self, signal):
         """Returns the indices for the provided signal for which NO signal instance has been emitted yet."""
         return [index for index in self._signals_map[signal] if self._signals_emitted[index] == False]
+
+    def _are_signal_names_available(self):
+        if self._signal_names:
+            return True
+        return False
+
+    def _get_degenerate_error_message(self):
+        received_signals = sum(self._signals_emitted)
+        total_signals = len(self._signals_emitted)
+        return "Received {actual} of the {total} expected signals. " \
+               "To improve this error message, provide the names of the signals " \
+               "in the waitSignals() call.".format(actual=received_signals, total=total_signals)
+
+    def _get_expected_and_actual_signals_message(self):
+        if not self.all_signals_and_args:
+            emitted_signals = "None"
+        else:
+            emitted_signal_string_list = [str(_) for _ in self.all_signals_and_args]
+            emitted_signals = self._format_as_array(emitted_signal_string_list)
+
+        missing_signal_strings = []
+        for missing_signal_index in self._get_missing_signal_indices():
+            missing_signal_strings.append(self._get_signal_string_representation_for_index(missing_signal_index))
+        missing_signals = self._format_as_array(missing_signal_strings)
+
+        return "Emitted signals: {}. Missing: {}".format(emitted_signals, missing_signals)
+
+    @staticmethod
+    def _format_as_array(list_of_strings):
+        return "[{}]".format(', '.join(list_of_strings))
+
+    def _get_order_violation_message(self):
+        expected_signal_as_str = self._get_signal_string_representation_for_index(self._signal_expected_index)
+        actual_signal_as_str = str(self._actual_signal_and_args_at_violation)
+        return "Signal order violated! Expected {expected} as {ordinal} signal, " \
+               "but received {actual} instead. ".format(expected=expected_signal_as_str,
+                                                        ordinal=get_ordinal_str(self._signal_expected_index + 1),
+                                                        actual=actual_signal_as_str)
+
+    def _get_missing_signal_indices(self):
+        return [index for index, value in enumerate(self._signals_emitted) if not self._signals_emitted[index]]
+
+    def _get_signal_string_representation_for_index(self, index):
+        """Returns something like <name_of_signal> or <name_of_signal> (callback: <name_of_callback>)"""
+        signal = self._get_signal_for_index(index)
+        signal_str_repr = self._signal_names[signal]
+
+        if self._check_params_callbacks:
+            potential_callback = self._check_params_callbacks[index]
+            if potential_callback:
+                callback_name = self.get_callback_name(potential_callback)
+                if callback_name:
+                    signal_str_repr += " (callback: {})".format(callback_name)
+
+        return signal_str_repr
+
+    def _get_signal_for_index(self, index):
+        for signal in self._signals_map:
+            if index in self._signals_map[signal]:
+                return signal
 
     def _cleanup(self):
         super(MultiSignalBlocker, self)._cleanup()

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -65,7 +65,8 @@ class _AbstractSignalBlocker(object):
             self._timer = None
 
     def get_timeout_error_message(self):
-        pass
+        """Subclasses have to implement this, returning an appropriate error message for a SignalTimeoutError."""
+        raise NotImplementedError
 
     def _extract_pyqt_signal_name(self, potential_pyqt_signal):
         signal_name = potential_pyqt_signal.signal  # type: str

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -453,7 +453,7 @@ def test_signalandargs_equality():
 def test_signalandargs_inequality():
     signal_args1_1 = SignalAndArgs(signal_name="signal", args=(1,2))
     signal_args1_2 = "foo"
-    assert signal_args1_1 == signal_args1_2
+    assert signal_args1_1 != signal_args1_2
 
 
 def get_waitsignals_cases_all(order):

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -830,6 +830,8 @@ class TestWaitSignalSignalTimeoutErrorMessage:
         parameters = "[('1', 1), ('2', 2)]"
         if PY_2:
             parameters = "[(u'1', 1), (u'2', 2)]"
+            if qt_api.pytest_qt_api == 'pyqt4':
+                parameters = "[(PyQt4.QtCore.QString(u'1'), 1), (PyQt4.QtCore.QString(u'2'), 2)]"
         assert ex_msg == ("Signal signal_args(QString,int) emitted with parameters {} "
                           "within 200 ms, but did not satisfy the arg_validator callback").format(parameters)
 
@@ -889,6 +891,8 @@ class TestWaitSignalsSignalTimeoutErrorMessage:
         signal_args = "'1', 1"
         if PY_2:
             signal_args = "u'1', 1"
+            if qt_api.pytest_qt_api == 'pyqt4':
+                signal_args = "PyQt4.QtCore.QString(u'1'), 1"
         assert ex_msg == ("Emitted signals: [signal_args({})]. Missing: "
                           "[signal(), signal_args(QString,int) (callback: my_callback_2)]").format(signal_args)
 
@@ -918,6 +922,8 @@ class TestWaitSignalsSignalTimeoutErrorMessage:
         signal_args = "'1', 1"
         if PY_2:
             signal_args = "u'1', 1"
+            if qt_api.pytest_qt_api == 'pyqt4':
+                signal_args = "PyQt4.QtCore.QString(u'1'), 1"
         assert ex_msg == ("Emitted signals: [signal_args({})]. Missing: "
                           "[signal(), signal_args(QString,int), signal_args(QString,int)]").format(signal_args)
 
@@ -936,6 +942,8 @@ class TestWaitSignalsSignalTimeoutErrorMessage:
         signal_args = "'1', 1"
         if PY_2:
             signal_args = "u'1', 1"
+            if qt_api.pytest_qt_api == 'pyqt4':
+                signal_args = "PyQt4.QtCore.QString(u'1'), 1"
         assert ex_msg == ("Signal order violated! Expected signal() as 1st signal, "
                           "but received signal_args({}) instead. Emitted signals: [signal_args({}), signal]. "
                           "Missing: [signal(), signal_args(QString,int), signal_args(QString,int)]").format(signal_args,

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -840,8 +840,13 @@ class TestWaitSignalSignalTimeoutErrorMessage:
     def test_unable_to_get_callback_name(self, qtbot, signaller):
         """
         Test that for complicated callbacks which aren't callables, but e.g. double-wrapped partials, the test code
-        is unable to determine the name of the callback.
+        is sometimes unable to determine the name of the callback.
+        Note that this behavior changes with Python 3.5, where a functools.partial() is smart enough to detect wrapped
+        calls.
         """
+        if sys.version_info >= (3,5):
+            pytest.skip("Only on Python 3.4 and lower double-wrapped functools.partial callbacks are a problem")
+
         if qt_api.pytest_qt_api == 'pyside':
             signal = (signaller.signal_single_arg, "signal_single_arg(int)")
         else:

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -429,14 +429,14 @@ def test_invalid_signal_tuple_length(qtbot, signaller):
 
 
 def test_provided_empty_signal_name(qtbot, signaller):
-    """Test that a TypeError is raised when providing a signal+name tuple where the name is an empty string."""
-    with pytest.raises(TypeError):
+    """Test that a ValueError is raised when providing a signal+name tuple where the name is an empty string."""
+    with pytest.raises(ValueError):
         invalid_signal_tuple = (signaller.signal, "")
         with qtbot.waitSignal(signal=invalid_signal_tuple, raising=False):
             pass
 
 
-def test_provided_invalid_signal_name(qtbot, signaller):
+def test_provided_invalid_signal_name_type(qtbot, signaller):
     """Test that a TypeError is raised when providing a signal+name tuple where the name is not actually string."""
     with pytest.raises(TypeError):
         invalid_signal_tuple = (signaller.signal, 12345)  # 12345 is not a signal name

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -405,6 +405,45 @@ def test_signal_identity(signaller):
     assert str(x) != str(z)
 
 
+def test_invalid_signal(qtbot):
+    """Tests that a TypeError is raised when providing a signal object that actually is not a Qt signal at all."""
+
+    class NotReallyASignal:
+        def __init__(self):
+            self.signal = False
+
+    with pytest.raises(TypeError):
+        with qtbot.waitSignal(signal=NotReallyASignal(), raising=False):
+            pass
+
+
+def test_invalid_signal_tuple_length(qtbot, signaller):
+    """
+    Test that a ValueError is raised when not providing a signal+name tuple with exactly 2 elements
+    as signal parameter.
+    """
+    with pytest.raises(ValueError):
+        signal_tuple_with_invalid_length = (signaller.signal, "signal()", "does not belong here")
+        with qtbot.waitSignal(signal=signal_tuple_with_invalid_length, raising=False):
+            pass
+
+
+def test_provided_empty_signal_name(qtbot, signaller):
+    """Test that a TypeError is raised when providing a signal+name tuple where the name is an empty string."""
+    with pytest.raises(TypeError):
+        invalid_signal_tuple = (signaller.signal, "")
+        with qtbot.waitSignal(signal=invalid_signal_tuple, raising=False):
+            pass
+
+
+def test_provided_invalid_signal_name(qtbot, signaller):
+    """Test that a TypeError is raised when providing a signal+name tuple where the name is not actually string."""
+    with pytest.raises(TypeError):
+        invalid_signal_tuple = (signaller.signal, 12345)  # 12345 is not a signal name
+        with qtbot.waitSignal(signal=invalid_signal_tuple, raising=False):
+            pass
+
+
 def get_waitsignals_cases_all(order):
     """
     Returns the list of tuples (emitted-signal-list, expected-signal-list, expect_signal_triggered) for the


### PR DESCRIPTION
``waitSignal()``: added support for capturing arguments when callback was not satisfied (into ``blocker.all_args``) and improved the message of ``SignalTimeoutError`` to include the name of the signal, non-matching signal parameters and name of the callback.

``waitSignals()``: Added capturing signals and their arguments (see ``all_signals_and_args``). Cleaned up large parts of the code of ``MultiSignalBlocker`` for better readability. Improved the message of ``SignalTimeoutError``. Updated documentation. Added tests. See #151 