### PR TITLE
WIP: Add qtbot.waitCallback

### DIFF
--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -305,8 +305,8 @@ class SignalTimeoutError(Exception):
     """
     .. versionadded:: 1.4
 
-    The exception thrown by :meth:`pytestqt.qtbot.QtBot.waitSignal` if the
-    *raising* parameter has been given and there was a timeout.
+    The exception thrown by :meth:`pytestqt.qtbot.QtBot.waitSignal` if there
+    was a timeout and raising was not turned off.
     """
     pass
 

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -301,6 +301,90 @@ class SignalEmittedSpy(object):
                                          (self.signal,))
 
 
+class CallbackBlocker(object):
+
+    """
+    .. versionadded:: 2.1
+
+    An object which checks if the returned callback gets called.
+
+    Intended to be used as a context manager.
+
+    :ivar int timeout: maximum time to wait for the callback to be called.
+
+    :ivar bool raising:
+        If :class:`CallbackTimeoutError` should be raised if a timeout occured.
+
+        .. note:: contrary to the parameter of same name in
+            :meth:`pytestqt.qtbot.QtBot.waitCallback`, this parameter does not
+            consider the :ref:`qt_wait_signal_raising` option.
+
+    :ivar list args:
+        The arguments with which the callback was called, or None if the
+        callback wasn't called at all.
+
+    :ivar dict kwargs:
+        The keyword arguments with which the callback was called, or None if
+        the callback wasn't called at all.
+    """
+
+    def __init__(self, timeout=1000, raising=True):
+        self.timeout = timeout
+        self.raising = raising
+        self.args = None
+        self.kwargs = None
+        self.called = False
+        self._loop = QtCore.QEventLoop()
+        self._timer = QtCore.QTimer(self._loop)
+        self._timer.setSingleShot(True)
+        self._timer.setInterval(timeout)
+
+    def _quit_loop_by_timeout(self):
+        try:
+            self._cleanup()
+        finally:
+            self._loop.quit()
+
+    def _cleanup(self):
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+
+    def wait(self):
+        """
+        Waits until either the returned callback is called or timeout is
+        reached.
+        """
+        __tracebackhide__ = True
+        if self.called:
+            return
+        if self._timer is not None:
+            self._timer.timeout.connect(self._quit_loop_by_timeout)
+            self._timer.start()
+        self._loop.exec_()
+        if not self.called and self.raising:
+            raise CallbackTimeoutError("Callback wasn't called after %sms." %
+                                       self.timeout)
+
+    def __call__(self, *args, **kwargs):
+        try:
+            self.args = list(args)
+            self.kwargs = kwargs
+            self.called = True
+            self._cleanup()
+        finally:
+            self._loop.quit()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        __tracebackhide__ = True
+        if value is None:
+            # only wait if no exception happened inside the "with" block
+            self.wait()
+
+
 class SignalTimeoutError(Exception):
     """
     .. versionadded:: 1.4
@@ -317,6 +401,16 @@ class SignalEmittedError(Exception):
 
     The exception thrown by :meth:`pytestqt.qtbot.QtBot.assertNotEmitted` if a
     signal was emitted unexpectedly.
+    """
+    pass
+
+
+class CallbackTimeoutError(Exception):
+    """
+    .. versionadded:: 2.1
+
+    The exception thrown by :meth:`pytestqt.qtbot.QtBot.waitCallback` if there
+    was a timeout and raising was not turned off.
     """
     pass
 

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -86,7 +86,7 @@ class SignalBlocker(_AbstractSignalBlocker):
 
         .. note:: contrary to the parameter of same name in
             :meth:`pytestqt.qtbot.QtBot.waitSignal`, this parameter does not
-            consider the :ref:`qt_wait_signal_raising`.
+            consider the :ref:`qt_wait_signal_raising` option.
 
     :ivar list args:
         The arguments which were emitted by the signal, or None if the signal

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -270,25 +270,30 @@ def timer():
     timer.shutdown()
 
 
-@pytest.mark.parametrize('multiple', [True, False])
+@pytest.mark.parametrize('blocker', ['single', 'multiple', 'callback'])
 @pytest.mark.parametrize('raising', [True, False])
-def test_wait_signals_handles_exceptions(qtbot, multiple, raising, signaller):
+def test_blockers_handle_exceptions(qtbot, blocker, raising, signaller):
     """
-    Make sure waitSignal handles exceptions correctly.
+    Make sure blockers handle exceptions correctly.
     """
 
     class TestException(Exception):
         pass
 
-    if multiple:
+    if blocker == 'multiple':
         func = qtbot.waitSignals
-        arg = [signaller.signal, signaller.signal_2]
-    else:
+        args = [[signaller.signal, signaller.signal_2]]
+    elif blocker == 'single':
         func = qtbot.waitSignal
-        arg = signaller.signal
+        args = [signaller.signal]
+    elif blocker == 'callback':
+        func = qtbot.waitCallback
+        args = []
+    else:
+        assert False
 
     with pytest.raises(TestException):
-        with func(arg, timeout=10, raising=raising):
+        with func(*args, timeout=10, raising=raising):
             raise TestException
 
 
@@ -668,3 +673,36 @@ class TestAssertNotEmitted:
         with qtbot.assertNotEmitted(signaller.signal):
             pass
         signaller.signal.emit()
+
+
+class TestWaitCallback:
+
+    def test_immediate(self, qtbot):
+        with qtbot.waitCallback() as callback:
+            assert not callback.called
+            callback()
+        assert callback.called
+
+    def test_later(self, qtbot):
+        t = QtCore.QTimer()
+        t.setSingleShot(True)
+        t.setInterval(50)
+        with qtbot.waitCallback() as callback:
+            t.timeout.connect(callback)
+            t.start()
+        assert callback.called
+
+    def test_args(self, qtbot):
+        with qtbot.waitCallback() as callback:
+            callback(23, answer=42)
+        assert callback.args == [23]
+        assert callback.kwargs == {'answer': 42}
+
+    def test_explicit(self, qtbot):
+        blocker = qtbot.waitCallback()
+        assert not blocker.called
+        blocker()
+        blocker.wait()
+        assert blocker.called
+
+    # FIXME tests for timeouts


### PR DESCRIPTION
Some TODO items and questions:
- [ ] Add tests for timeouts
- [ ] Any other tests?
- [ ] Add docs (in `signals.rst`?)
- [ ] Should we re-use `qt_wait_signal_raising`? Or have a different config option? Or rename `qt_wait_signal_raising` to `qt_raising`, use it for both, and have `qt_wait_signal_raising` as deprecated alias?
- [ ] Should we re-use `SignalTimeoutError`? Or have the current `CallbackTimeoutError`? Or rename `SignalTimeoutError` to `TimeoutError`, use it for both, and have `SignalTimeoutError` as deprecated alias?
- [ ] Should I inherit from some `AbstractBlocker` instead of copy-pasting some code to `CallbackBlocker`? I thought it'd make stuff too complicated and a little copy-paste is probably simpler.
