### PR TITLE
Install PyQt5 from PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 
 virtualenv:
   system_site_packages: true
@@ -13,6 +14,14 @@ matrix:
   exclude:
     - env: PYTEST_QT_API=pyqt5
       python: "2.7"
+    - env: PYTEST_QT_API=pyqt5
+      python: "3.4"
+    - env: PYTEST_QT_API=pyqt4
+      python: "3.5"
+    - env: PYTEST_QT_API=pyqt4v2
+      python: "3.5"
+    - env: PYTEST_QT_API=pyside
+      python: "3.5"
 
 env:
  - PYTEST_QT_API=pyqt4

--- a/README.rst
+++ b/README.rst
@@ -131,15 +131,16 @@ fixed, and make sure to include yourself in the contributors list. :)
 Running tests
 -------------
 
-Tests are run using `tox`_. The simplest way to test is with `PySide`_, as it
-is available on pip and can be installed by ``tox`` automatically::
+Tests are run using `tox`_. The simplest way to test is with `PySide`_ or Python
+3.5 with PyQt5, as they are available on pip and can be installed by ``tox``
+automatically::
 
-    $ tox -e py34-pyside,py27-pyside,docs
+    $ tox -e py35-pyqt5,py34-pyside,py27-pyside,docs
 
-If you want to test against `PyQt`_, install it into your global python
-installation and use the ``py27-pyqt4``, ``py34-pyqt4`` or ``py34-pyqt5``
-testing environments, and ``tox`` will copy the appropriate files into
-its virtual environments to ensure isolation.
+If you want to test against other `PyQt`_ combinations, install it into your
+global python installation and use the ``py27-pyqt4``, ``py34-pyqt4`` or
+``py34-pyqt5`` testing environments, and ``tox`` will copy the appropriate files
+into its virtual environments to ensure isolation.
 
 Contributors
 ------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 environment:
   matrix:
-    - INSTALL_QT: "py34-pyqt5"
-      TESTENVS: "py34-pyqt5"
-
     - INSTALL_QT: "py35-pyqt5"
       TESTENVS: "py35-pyqt5"
 

--- a/scripts/install-qt.py
+++ b/scripts/install-qt.py
@@ -60,7 +60,7 @@ if 'APPVEYOR' in os.environ:
     else:
         print('Skip install for this build')
 
-elif 'TRAVIS' in os.environ:
+elif 'TRAVIS' in os.environ and os.environ['PYTEST_QT_API'] != 'pyqt5':
     def apt_get_install(packages):
         print('Installing %s...' % ', '.join(packages))
         subprocess.check_call(['sudo', 'apt-get', 'install', '-y', '-qq'] + packages)
@@ -85,4 +85,4 @@ elif 'TRAVIS' in os.environ:
         apt_get_install([pkg])
 
 else:
-    print('Nothing to do (not in Travis or AppVeyor)')
+    print('Nothing to do (PyQt5, or not on Travis/AppVeyor)')

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ envlist = py{27,34}-pyqt4, py{34,35}-pyqt5, py{27,34,35}-pyside, lint
 
 [testenv]
 deps=pytest
-    pyside: pyside
+     pyside: pyside
+     pyqt5: pyqt5
 changedir=tests
 commands=
-    pyqt5: {envpython} ../scripts/link_pyqt.py --tox {envdir} 5
     pyqt4: {envpython} ../scripts/link_pyqt.py --tox {envdir} 4
     {envpython} -m pytest {posargs}
 setenv=


### PR DESCRIPTION
Since PyQt5 5.6 it's available as binary wheel including Qt on PyPI.
This will make it easier for contributors too, as they can simply run
tox.
