### PR TITLE
Fix API error message and tests on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 python:
   - "2.7"
   - "3.4"
-  - "3.6"
 
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 python:
   - "2.7"
   - "3.4"
+  - "3.6"
 
 virtualenv:
   system_site_packages: true

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -31,7 +31,7 @@ class _QtApi:
             api = api.lower()
             if api not in ('pyside', 'pyqt4', 'pyqt4v2', 'pyqt5'):  # pragma: no cover
                 msg = 'Invalid value for $PYTEST_QT_API: %s'
-                raise RuntimeError(msg % qt_api)
+                raise RuntimeError(msg % api)
         return api
 
     def _guess_qt_api(self):  # pragma: no cover

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -353,3 +353,17 @@ def test_qt_api_ini_config(testdir, option_api):
             '*ImportError:*'
         ])
 
+
+def test_invalid_qt_api_envvar(testdir, monkeypatch):
+    """
+    Make sure the error message with an invalid PYQTEST_QT_API is correct.
+    """
+    testdir.makepyfile('''
+        import pytest
+
+        def test_foo(qtbot):
+            pass
+    ''')
+    monkeypatch.setenv('PYTEST_QT_API', 'piecute')
+    result = testdir.runpytest_subprocess()
+    result.stderr.fnmatch_lines(['* Invalid value for $PYTEST_QT_API: piecute'])

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -349,9 +349,18 @@ def test_qt_api_ini_config(testdir, option_api):
             '* 1 passed in *'
         ])
     else:
-        result.stderr.fnmatch_lines([
-            '*ImportError:*'
-        ])
+        try:
+            ModuleNotFoundError
+        except NameError:
+            # Python < 3.6
+            result.stderr.fnmatch_lines([
+                '*ImportError:*'
+            ])
+        else:
+            # Python >= 3.6
+            result.stderr.fnmatch_lines([
+                '*ModuleNotFoundError:*'
+            ])
 
 
 def test_invalid_qt_api_envvar(testdir, monkeypatch):


### PR DESCRIPTION
The error was wrong:

```
INTERNALERROR> RuntimeError: Invalid value for $PYTEST_QT_API: <pytestqt.qt_compat._QtApi object at 0x7f00b76f2198>
```

I also fixed some test breakage on Python 3.6 and added it to Travis - let me know if you want a separate PR for that instead :wink: