### PR TITLE
Fix issue where pytestqt was hiding the information when there's an exception raised from another exception on Python 3

### DIFF
--- a/pytestqt/exceptions.py
+++ b/pytestqt/exceptions.py
@@ -70,8 +70,7 @@ def format_captured_exceptions(exceptions):
     message = 'Qt exceptions in virtual methods:\n'
     message += '_' * 80 + '\n'
     for (exc_type, value, tback) in exceptions:
-        message += ''.join(traceback.format_tb(tback)) + '\n'
-        message += '%s: %s\n' % (exc_type.__name__, value)
+        message += ''.join(traceback.format_exception(exc_type, value, tback)) + '\n'
         message += '_' * 80 + '\n'
     return message
 


### PR DESCRIPTION
This change makes a change to use print_exception instead of rolling your own when on Python 3. I've done the change on the fly here, so, it may need better tests on Python 3 (and alternatively, the same could be used on Python 2, but in that case io.StringIO may not work and may need StringIO.StringIO).