### PR TITLE
Fix master on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,16 @@
-language: python
+language: generic
 sudo: required
 dist: trusty
 
-python:
-  - "2.7"
-  - "3.4"
-
-virtualenv:
-  system_site_packages: true
-
-matrix:
-  exclude:
-    - env: PYTEST_QT_API=pyqt5
-      python: "2.7"
-
 env:
- - PYTEST_QT_API=pyqt4
- - PYTEST_QT_API=pyqt4v2
- - PYTEST_QT_API=pyside
- - PYTEST_QT_API=pyqt5
+ - PYTEST_QT_API=pyqt4   PYTHON=python2.7
+ - PYTEST_QT_API=pyqt4v2 PYTHON=python2.7
+ - PYTEST_QT_API=pyside  PYTHON=python2.7
+
+ - PYTEST_QT_API=pyqt4   PYTHON=python3.4
+ - PYTEST_QT_API=pyqt4v2 PYTHON=python3.4
+ - PYTEST_QT_API=pyside  PYTHON=python3.4
+ - PYTEST_QT_API=pyqt5   PYTHON=python3.4
 
 install:
  - sudo apt-get update
@@ -27,16 +19,17 @@ install:
  - sudo apt-get install -y xvfb herbstluftwm
 
  # Qt
- - python scripts/install-qt.py
+ - $PYTHON scripts/install-qt.py
 
- # PyTest
- - pip install -U pytest
+ # Pip (3.4 does not have it by default)
+ - wget https://bootstrap.pypa.io/get-pip.py
+ - sudo $PYTHON get-pip.py
 
- # Tox
- - pip install -U tox
+ # Dependencies
+ - sudo $PYTHON -m pip install -U pytest tox coveralls
 
- # others
- - pip install coveralls --use-wheel
+ # pytest-qt
+ - sudo $PYTHON setup.py develop
 
 before_script:
  - "export DISPLAY=:99.0"
@@ -46,9 +39,8 @@ before_script:
  - sleep 1
 
 script:
- - python setup.py develop
- - catchsegv coverage run --source=pytestqt setup.py test
- - tox -e lint
+ - sudo catchsegv coverage run --source=pytestqt setup.py test
+ - sudo tox -e lint
 
 after_success:
  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 
 before_script:
  - "export DISPLAY=:99.0"
- - "sh -e /etc/init.d/xvfb start"
+ - start-stop-daemon --start --background --exec /usr/bin/Xvfb -- $DISPLAY -screen 0 1024x768x24
  - sleep 3 # give xvfb some time to start
  - "herbstluftwm &"
  - sleep 1

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv=
 passenv=DISPLAY XAUTHORITY USER USERNAME
 
 [testenv:lint]
-basepython=python3.5
+basepython=python3.4
 deps=
     pytest
     sphinx


### PR DESCRIPTION
Using system python directly, given that the old approach no longer works. 

This is related to the recently published new trusty image, given that setting `group: deprecated-2017Q2` made the build work again in my tests.