### PR TITLE
Pyside2 support (continued..)

### DIFF
--- a/.pydevproject
+++ b/.pydevproject
@@ -2,6 +2,7 @@
 <?eclipse-pydev version="1.0"?><pydev_project>
 <pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
 <path>/${PROJECT_DIR_NAME}</path>
+<path>/${PROJECT_DIR_NAME}/tests</path>
 </pydev_pathproperty>
 <pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
 <pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
       - PYTEST_QT_API=pyqt4v2 PYQT_PACKAGE="pyqt=4.*" PYTHON_VERSION=3.4
       - PYTEST_QT_API=pyside  PYQT_PACKAGE="pyside=1.*" PYTHON_VERSION=3.4
       - PYTEST_QT_API=pyqt5   PYQT_PACKAGE="pyqt=5.*" PYTHON_VERSION=3.4
+      - PYTEST_QT_API=pyside2   PYQT_PACKAGE="pyside2=2.*" PYTHON_VERSION=3.5
 
 install:
  - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
  - sleep 1
 
 script:
- - source activate test && catchsegv coverage run --source=pytestqt -m pytest tests
+ - source activate test && catchsegv coverage run --source=pytestqt -m pytest -v tests
  # for some reason tox doesn't get installed with a u+x flag
  - | 
      chmod u+x /home/travis/miniconda/envs/test/bin/tox 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ pytest-qt
 =========
 
 pytest-qt is a `pytest`_ plugin that allows programmers to write tests
-for `PySide`_ and `PyQt`_ applications.
+for `PySide`_, `PySide2` and `PyQt`_ applications.
 
 The main usage is to use the `qtbot` fixture, responsible for handling `qApp` 
 creation as needed and provides methods to simulate user interaction, 
@@ -23,6 +23,7 @@ like key presses and mouse clicks:
 
 
 .. _PySide: https://pypi.python.org/pypi/PySide
+.. _PySide2: https://wiki.qt.io/PySide2
 .. _PyQt: http://www.riverbankcomputing.com/software/pyqt
 .. _pytest: http://pytest.org
 
@@ -72,16 +73,17 @@ Features
 Requirements
 ============
 
-Works with either PySide_ or PyQt_ (``PyQt5`` and ``PyQt4``) picking whichever
+Works with either PySide_, PySide2_ or PyQt_ (``PyQt5`` and ``PyQt4``) picking whichever
 is available on the system, giving preference to the first one installed in
 this order:
 
+- ``PySide2``
 - ``PyQt5``
 - ``PySide``
 - ``PyQt4``
 
 To force a particular API, set the configuration variable ``qt_api`` in your ``pytest.ini`` file to
-``pyqt5``, ``pyside``, ``pyqt4`` or ``pyqt4v2``. ``pyqt4v2`` sets the ``PyQt4``
+``pyqt5``, ``pyside``, ``pyside2``, ``pyqt4`` or ``pyqt4v2``. ``pyqt4v2`` sets the ``PyQt4``
 API to `version 2`_.
 
 .. code-block:: ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,4 +60,4 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% python -m pytest tests/"
+  - "%CMD_IN_ENV% python -m pytest -v tests/"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,9 @@ environment:
     - PYTHON_VERSION: "3.4"
       PYTEST_QT_API: "pyqt5"
       CONDA_DEPENDENCIES: "pytest pyqt=5.*"
+    - PYTHON_VERSION: "3.5"
+      PYTEST_QT_API: "pyside2"
+      CONDA_DEPENDENCIES: "pytest pyside2=2.*"
 
 platform:
     -x64

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -43,12 +43,12 @@ class _QtApi:
 
         # Note, not importing only the root namespace because when uninstalling from conda,
         # the namespace can still be there.
-        if _can_import('PyQt5.QtCore'):
+        if _can_import('PySide2.QtCore'):
+            return 'pyside2'
+        elif _can_import('PyQt5.QtCore'):
             return 'pyqt5'
         elif _can_import('PySide.QtCore'):
             return 'pyside'
-        elif _can_import('PySide2.QtCore'):
-            return 'pyside2'
         elif _can_import('PyQt4.QtCore'):
             return 'pyqt4'
         return None
@@ -104,7 +104,7 @@ class _QtApi:
         self.qInstallMsgHandler = None
         self.qInstallMessageHandler = None
 
-        if self.pytest_qt_api in ('pyside', 'pyside2'):
+        if self.pytest_qt_api.startswith('pyside'):
             self.Signal = QtCore.Signal
             self.Slot = QtCore.Slot
             self.Property = QtCore.Property

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -108,8 +108,6 @@ class _QtApi:
             self.Signal = QtCore.Signal
             self.Slot = QtCore.Slot
             self.Property = QtCore.Property
-            self.QApplication = QtGui.QApplication
-            self.QWidget = QtGui.QWidget
             self.QStringListModel = QtGui.QStringListModel
 
             self.QStandardItem = QtGui.QStandardItem

--- a/pytestqt/qtbot.py
+++ b/pytestqt/qtbot.py
@@ -218,7 +218,7 @@ class QtBot(object):
 
         .. note:: This method is also available as ``wait_for_window_shown`` (pep-8 alias)
         """
-        if qt_api.pytest_qt_api == 'pyqt5':
+        if hasattr(qt_api.QtTest.QTest, 'qWaitForWindowExposed'):
             return qt_api.QtTest.QTest.qWaitForWindowExposed(widget)
         else:
             return qt_api.QtTest.QTest.qWaitForWindowShown(widget)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -324,7 +324,7 @@ def test_parse_ini_boolean_invalid():
         pytestqt.qtbot._parse_ini_boolean('foo')
 
 
-@pytest.mark.parametrize('option_api', ['pyqt4', 'pyqt5', 'pyside'])
+@pytest.mark.parametrize('option_api', ['pyqt4', 'pyqt5', 'pyside', 'pyside2'])
 def test_qt_api_ini_config(testdir, option_api):
     """
     Test qt_api ini option handling.
@@ -344,7 +344,7 @@ def test_qt_api_ini_config(testdir, option_api):
     ''')
 
     result = testdir.runpytest_subprocess()
-    if qt_api.pytest_qt_api.startswith(option_api):  # handle pyqt4v2
+    if qt_api.pytest_qt_api.replace('v2', '') == option_api:  # handle pyqt4v2
         result.stdout.fnmatch_lines([
             '* 1 passed in *'
         ])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,6 +4,8 @@ import pytest
 
 from pytestqt.qt_compat import qt_api
 
+pytestmark = pytest.mark.skipif(qt_api.pytest_qt_api == 'pyside2', reason="https://bugreports.qt.io/browse/PYSIDE-435")
+
 
 @pytest.mark.parametrize('test_succeeds', [True, False])
 @pytest.mark.parametrize('qt_log', [True, False])

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -4,7 +4,7 @@ import pytest
 from pytestqt.qt_compat import qt_api
 
 
-fails_on_pyqt = pytest.mark.xfail('qt_api.pytest_qt_api != "pyside"')
+fails_on_pyqt = pytest.mark.xfail('qt_api.pytest_qt_api not in ("pyside", "pyside2")')
 
 
 @pytest.mark.parametrize('expected_method', [

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -4,7 +4,7 @@ import pytest
 from pytestqt.qt_compat import qt_api
 
 
-fails_on_pyqt = pytest.mark.xfail('qt_api.pytest_qt_api not in ("pyside", "pyside2")')
+fails_on_pyqt = pytest.mark.xfail('not qt_api.pytest_qt_api.startswith("pyside")')
 
 
 @pytest.mark.parametrize('expected_method', [

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -290,36 +290,22 @@ def test_wait_signals_invalid_strict_parameter(qtbot, signaller):
 
 def test_destroyed(qtbot):
     """Test that waitSignal works with the destroyed signal (#82).
+
+    For some reason, this crashes PySide although it seems perfectly fine code.
     """
     if qt_api.pytest_qt_api.startswith('pyside'):
-        # PySide uses shiboken instead of sip.
-        if qt_api.pytest_qt_api == 'pyside':
-            try:
-                from PySide import shiboken
-            except ImportError:
-                import shiboken
-        else:
-            from PySide2 import shiboken2 as shiboken
+        pytest.skip('test crashes PySide and PySide2')
 
-        class Obj(qt_api.QtCore.QObject):
-            pass
+    import sip
 
-        obj = Obj()
-        with qtbot.waitSignal(obj.destroyed):
-            obj.deleteLater()
+    class Obj(qt_api.QtCore.QObject):
+        pass
 
-        assert not shiboken.isValid(obj)
-    else:
-        import sip
+    obj = Obj()
+    with qtbot.waitSignal(obj.destroyed):
+        obj.deleteLater()
 
-        class Obj(qt_api.QtCore.QObject):
-            pass
-
-        obj = Obj()
-        with qtbot.waitSignal(obj.destroyed):
-            obj.deleteLater()
-
-        assert sip.isdeleted(obj)
+    assert sip.isdeleted(obj)
 
 
 class TestArgs:
@@ -1013,7 +999,7 @@ class TestWaitSignalsTimeoutErrorMessage:
         by the user. This degenerate messages doesn't contain the signals' names, and includes a hint to the user how
         to fix the situation.
         """
-        if qt_api.pytest_qt_api not in ('pyside', 'pyside2'):
+        if not qt_api.pytest_qt_api.startswith('pyside'):
             pytest.skip("test only makes sense for PySide, whose signals don't contain a name!")
 
         with pytest.raises(TimeoutError) as excinfo:


### PR DESCRIPTION
Continuation of https://github.com/pytest-dev/pytest-qt/pull/161 by @fabioz aiming to add PySide2 support.

This PR,
  * addresses review comments from https://github.com/pytest-dev/pytest-qt/pull/161
  * adds CI setup
  * removes the attempt to fix `test_wait_signal.py::test_destroyed` for PySide* as I have not managed to make this change pass CI (see https://github.com/pytest-dev/pytest-qt/issues/183).
  * also change pytest to the verbose mode in CI so that in case of segfault in Appveyor, it's more evident which test caused it..