### PR TITLE
updated modeltester to allow QBrush as BackgroundColorRole

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 env:
   global:
       # used by ci-helpers
-      - CONDA_CHANNELS=conda-forge SETUP_XVFB=true  DEPS="pytest tox coveralls"
+      - CONDA_CHANNELS=conda-forge SETUP_XVFB=true  DEPS="pytest tox coveralls six"
 
   matrix:
       - PYTEST_QT_API=pyqt4   PYQT_PACKAGE="pyqt=4.*" PYTHON_VERSION=2.7
@@ -28,7 +28,7 @@ install:
  # Xvfb / window manager
  - sudo apt-get install -y xvfb herbstluftwm
 
- # Setup miniconda 
+ # Setup miniconda
  - git clone --depth 1 git://github.com/astropy/ci-helpers.git
  - CONDA_DEPENDENCIES="${DEPS} ${PYQT_PACKAGE}" source ci-helpers/travis/setup_conda.sh
  - source activate test && pip install -e .
@@ -41,8 +41,8 @@ before_script:
 script:
  - source activate test && catchsegv coverage run --source=pytestqt -m pytest -v tests
  # for some reason tox doesn't get installed with a u+x flag
- - | 
-     chmod u+x /home/travis/miniconda/envs/test/bin/tox 
+ - |
+     chmod u+x /home/travis/miniconda/envs/test/bin/tox
      /home/travis/miniconda/envs/test/bin/tox -e lint
 
 after_success:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+2.2.1
+-----
+
+- ``modeltester`` now accepts ``QBrush`` for ``BackgroundColorRole`` and ``TextColorRole`` (`#189`_).
+  Thanks `@p0las`_ for the PR.
+
+.. _#189: https://github.com/pytest-dev/pytest-qt/issues/189
+.. _@p0las: https://github.com/p0las
+
+
 2.2.0
 -----
 

--- a/pytestqt/modeltest.py
+++ b/pytestqt/modeltest.py
@@ -448,8 +448,8 @@ class ModelTester:
             (qt_api.QtCore.Qt.WhatsThisRole, str),
             (qt_api.QtCore.Qt.SizeHintRole, qt_api.QtCore.QSize),
             (qt_api.QtCore.Qt.FontRole, qt_api.QtGui.QFont),
-            (qt_api.QtCore.Qt.BackgroundColorRole, qt_api.QtGui.QColor),
-            (qt_api.QtCore.Qt.TextColorRole, qt_api.QtGui.QColor),
+            (qt_api.QtCore.Qt.BackgroundColorRole, (qt_api.QtGui.QColor, qt_api.QtGui.QBrush)),
+            (qt_api.QtCore.Qt.TextColorRole, (qt_api.QtGui.QColor, qt_api.QtGui.QBrush)),
         ]
 
         # General purpose roles with a fixed expected type
@@ -493,7 +493,7 @@ class ModelTester:
                         self._modelindex_debug(last_index),
                         self._modelindex_debug(next_index),
                     )
-        )
+                    )
 
         last_data = self._model.data(last_index)
         next_data = self._model.data(next_index)
@@ -518,7 +518,7 @@ class ModelTester:
                         qt_api.extract_from_variant(c.next),
                         qt_api.extract_from_variant(c.last)
                     )
-        )
+                    )
 
         self._debug("  now in rowsInserted:        parent {}, size {}, "
                     "next data {!r}, last data {!r}".format(
@@ -527,7 +527,7 @@ class ModelTester:
                         qt_api.extract_from_variant(next_data),
                         qt_api.extract_from_variant(last_data)
                     )
-        )
+                    )
 
         if not qt_api.QtCore.qVersion().startswith('4.'):
             # Skipping this on Qt4 as the parent changes for some reason:
@@ -577,7 +577,7 @@ class ModelTester:
                         self._modelindex_debug(last_index),
                         self._modelindex_debug(next_index),
                     )
-        )
+                    )
 
         last_data = self._model.data(last_index)
         next_data = self._model.data(next_index)
@@ -602,7 +602,7 @@ class ModelTester:
                         qt_api.extract_from_variant(c.next),
                         qt_api.extract_from_variant(c.last)
                     )
-        )
+                    )
 
         self._debug("  now in rowsRemoved:        parent {}, size {}, "
                     "next data {!r}, last data {!r}".format(
@@ -611,7 +611,7 @@ class ModelTester:
                         qt_api.extract_from_variant(next_data),
                         qt_api.extract_from_variant(last_data)
                     )
-        )
+                    )
 
         if not qt_api.QtCore.qVersion().startswith('4.'):
             # Skipping this on Qt4 as the parent changes for some reason

--- a/pytestqt/modeltest.py
+++ b/pytestqt/modeltest.py
@@ -493,7 +493,7 @@ class ModelTester:
                         self._modelindex_debug(last_index),
                         self._modelindex_debug(next_index),
                     )
-                    )
+        )
 
         last_data = self._model.data(last_index)
         next_data = self._model.data(next_index)
@@ -518,7 +518,7 @@ class ModelTester:
                         qt_api.extract_from_variant(c.next),
                         qt_api.extract_from_variant(c.last)
                     )
-                    )
+        )
 
         self._debug("  now in rowsInserted:        parent {}, size {}, "
                     "next data {!r}, last data {!r}".format(
@@ -527,7 +527,7 @@ class ModelTester:
                         qt_api.extract_from_variant(next_data),
                         qt_api.extract_from_variant(last_data)
                     )
-                    )
+        )
 
         if not qt_api.QtCore.qVersion().startswith('4.'):
             # Skipping this on Qt4 as the parent changes for some reason:
@@ -577,7 +577,7 @@ class ModelTester:
                         self._modelindex_debug(last_index),
                         self._modelindex_debug(next_index),
                     )
-                    )
+        )
 
         last_data = self._model.data(last_index)
         next_data = self._model.data(next_index)
@@ -602,7 +602,7 @@ class ModelTester:
                         qt_api.extract_from_variant(c.next),
                         qt_api.extract_from_variant(c.last)
                     )
-                    )
+        )
 
         self._debug("  now in rowsRemoved:        parent {}, size {}, "
                     "next data {!r}, last data {!r}".format(
@@ -611,7 +611,7 @@ class ModelTester:
                         qt_api.extract_from_variant(next_data),
                         qt_api.extract_from_variant(last_data)
                     )
-                    )
+        )
 
         if not qt_api.QtCore.qVersion().startswith('4.'):
             # Skipping this on Qt4 as the parent changes for some reason


### PR DESCRIPTION
pyQt5 takes QBrush as BackgroundColorRole and TextColorRole.