### PR TITLE
Add a qapp_args fixture

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+2.3.0
+-----
+
+- New ``qapp_args`` fixture which can be used to pass custom arguments to
+  ``QApplication``.
+  Thanks `@The-Compiler`_ for the PR.
+
 2.2.1
 -----
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -3,6 +3,7 @@ Reference
 
 QtBot
 -----
+
 .. module:: pytestqt.qtbot
 .. autoclass:: QtBot
 
@@ -32,3 +33,10 @@ Record
 
 .. module:: pytestqt.logging
 .. autoclass:: Record
+
+qapp fixture
+------------
+
+.. module:: pytestqt.plugin
+.. autofunction:: qapp
+.. autofunction:: qapp_args

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -21,7 +21,16 @@ assert format_captured_exceptions
 @pytest.fixture(scope='session')
 def qapp_args():
     """
-    Fixture providing QApplication arguments to use.
+    Fixture that provides QApplication arguments to use.
+
+    You can override this fixture to pass different arguments to
+    ``QApplication``:
+
+    .. code-block:: python
+
+       @pytest.fixture(scope='session')
+       def qapp_args():
+           return ['--arg']
     """
     return []
 
@@ -29,8 +38,11 @@ def qapp_args():
 @pytest.yield_fixture(scope='session')
 def qapp(qapp_args):
     """
-    fixture that instantiates the QApplication instance that will be used by
+    Fixture that instantiates the QApplication instance that will be used by
     the tests.
+
+    You can use the ``qapp`` fixture in tests which require a ``QApplication``
+    to run, but where you don't need full ``qtbot`` functionality.
     """
     app = qt_api.QApplication.instance()
     if app is None:

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -18,8 +18,16 @@ assert capture_exceptions
 assert format_captured_exceptions
 
 
+@pytest.fixture(scope='session')
+def qapp_args():
+    """
+    Fixture providing QApplication arguments to use.
+    """
+    return []
+
+
 @pytest.yield_fixture(scope='session')
-def qapp():
+def qapp(qapp_args):
     """
     fixture that instantiates the QApplication instance that will be used by
     the tests.
@@ -27,7 +35,7 @@ def qapp():
     app = qt_api.QApplication.instance()
     if app is None:
         global _qapp_instance
-        _qapp_instance = qt_api.QApplication([])
+        _qapp_instance = qt_api.QApplication(qapp_args)
         yield _qapp_instance
     else:
         yield app  # pragma: no cover


### PR DESCRIPTION
This makes it possible to pass custom arguments to Qt.

- I'm not sure how to test this yet - I can try something with `QCoreApplication.arguments()` and a subprocess, but I'm not sure whether it works.
- I'm also not sure where to document it, given that `qapp` isn't documented at all either. What do you think?