### PR TITLE
env variable wins over config value

### DIFF
--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -54,7 +54,7 @@ class _QtApi:
         return None
 
     def set_qt_api(self, api):
-        self.pytest_qt_api = api or self._get_qt_api_from_env() or self._guess_qt_api()
+        self.pytest_qt_api = self._get_qt_api_from_env() or api or self._guess_qt_api()
         if not self.pytest_qt_api:  # pragma: no cover
             msg = 'pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed'
             raise RuntimeError(msg)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -326,11 +326,13 @@ def test_parse_ini_boolean_invalid():
 
 
 @pytest.mark.parametrize('option_api', ['pyqt4', 'pyqt5', 'pyside', 'pyside2'])
-def test_qt_api_ini_config(testdir, option_api):
+def test_qt_api_ini_config(testdir, monkeypatch, option_api):
     """
     Test qt_api ini option handling.
     """
     from pytestqt.qt_compat import qt_api
+
+    monkeypatch.delenv("PYTEST_QT_API")
 
     testdir.makeini("""
         [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -33,4 +33,3 @@ setenv=
 commands=
     rst-lint {toxinidir}/CHANGELOG.rst {toxinidir}/README.rst
     sphinx-build -q -E -W -b html . _build
-


### PR DESCRIPTION
i believe that in the awkward case where you have `qt_api` and the `PYTEST_QT_API` set at the same time, the env variable should win according to the documentation
https://pytest-qt.readthedocs.io/en/latest/intro.html
