### PR TITLE
Fix QStringListModel error on PySide2

### DIFF
--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -108,13 +108,15 @@ class _QtApi:
             self.Signal = QtCore.Signal
             self.Slot = QtCore.Slot
             self.Property = QtCore.Property
-            self.QStringListModel = QtGui.QStringListModel
+            if hasattr(QtGui, 'QStringListModel'):
+                self.QStringListModel = QtGui.QStringListModel
+            else:
+                self.QStringListModel = QtCore.QStringListModel
 
             self.QStandardItem = QtGui.QStandardItem
             self.QStandardItemModel = QtGui.QStandardItemModel
             self.QAbstractListModel = QtCore.QAbstractListModel
             self.QAbstractTableModel = QtCore.QAbstractTableModel
-            self.QStringListModel = QtGui.QStringListModel
 
             if self.pytest_qt_api == 'pyside2':
                 _QtWidgets = _import_module('QtWidgets')


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-qt/issues/205

On PySide2,  `QStringModel` is not in QtGui but in QtCore, this applies the fix suggested by @nicoddemus 