### PR TITLE
Use Item.get_closest_marker on pytest 3.6

### DIFF
--- a/pytestqt/exceptions.py
+++ b/pytestqt/exceptions.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 import sys
 import traceback
 import pytest
+from pytestqt.utils import get_marker
 
 
 @contextmanager
@@ -78,7 +79,7 @@ def format_captured_exceptions(exceptions):
 def _is_exception_capture_enabled(item):
     """returns if exception capture is disabled for the given test item.
     """
-    disabled = item.get_marker('qt_no_exception_capture') or \
+    disabled = get_marker(item, 'qt_no_exception_capture') or \
                item.config.getini('qt_no_exception_capture')
     return not disabled
 

--- a/pytestqt/logging.py
+++ b/pytestqt/logging.py
@@ -5,6 +5,7 @@ import re
 from py._code.code import TerminalRepr, ReprFileLocation
 import pytest
 from pytestqt.qt_compat import qt_api
+from pytestqt.utils import get_marker
 
 
 class QtLoggingPlugin(object):
@@ -19,9 +20,9 @@ class QtLoggingPlugin(object):
         self.config = config
 
     def pytest_runtest_setup(self, item):
-        if item.get_marker('no_qt_log'):
+        if get_marker(item, 'no_qt_log'):
             return
-        m = item.get_marker('qt_log_ignore')
+        m = get_marker(item, 'qt_log_ignore')
         if m:
             if not set(m.kwargs).issubset(set(['extend'])):
                 raise ValueError("Invalid keyword arguments in {0!r} for "
@@ -46,7 +47,7 @@ class QtLoggingPlugin(object):
         if call.when == 'call':
             report = outcome.get_result()
 
-            m = item.get_marker('qt_log_level_fail')
+            m = get_marker(item, 'qt_log_level_fail')
             if m:
                 log_fail_level = m.args[0]
             else:

--- a/pytestqt/utils.py
+++ b/pytestqt/utils.py
@@ -1,0 +1,11 @@
+def get_marker(item, name):
+    """Get a marker from a pytest item.
+
+    This is here in order to stay compatible with pytest < 3.6 and not produce
+    any deprecation warnings with >= 3.6.
+    """
+    try:
+        return item.get_closest_marker(name)
+    except AttributeError:
+        # pytest < 3.6
+        return item.get_marker(name)


### PR DESCRIPTION
This avoids deprecation warnings on the upcoming pytest 3.6 release:
https://docs.pytest.org/en/features/mark.html#marker-revamp-and-iteration