### PR TITLE
Remove mouseEvent proxy method

### DIFF
--- a/pytestqt/qtbot.py
+++ b/pytestqt/qtbot.py
@@ -96,7 +96,6 @@ class QtBot(object):
 
     .. staticmethod:: mouseClick (widget, button[, stateKey=0[, pos=QPoint()[, delay=-1]]])
     .. staticmethod:: mouseDClick (widget, button[, stateKey=0[, pos=QPoint()[, delay=-1]]])
-    .. staticmethod:: mouseEvent (action, widget, button, stateKey, pos[, delay=-1])
     .. staticmethod:: mouseMove (widget[, pos=QPoint()[, delay=-1]])
     .. staticmethod:: mousePress (widget, button[, stateKey=0[, pos=QPoint()[, delay=-1]]])
     .. staticmethod:: mouseRelease (widget, button[, stateKey=0[, pos=QPoint()[, delay=-1]]])
@@ -549,7 +548,6 @@ class QtBot(object):
 
             'mouseClick',
             'mouseDClick',
-            'mouseEvent',
             'mouseMove',
             'mousePress',
             'mouseRelease',

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -18,7 +18,6 @@ fails_on_pyqt = pytest.mark.xfail('not qt_api.pytest_qt_api.startswith("pyside")
 
     'mouseClick',
     'mouseDClick',
-    'mouseEvent',
     'mouseMove',
     'mousePress',
     'mouseRelease',


### PR DESCRIPTION
`QTest::mouseEvent` was never documented in Qt, and it is marked as internal in Qt source code:

https://github.com/qt/qtbase/blob/74305ba470f48da8b4c4e806fc714fe9f7649156/src/testlib/qtestcase.qdoc#L1379-L1387

It was also removed in PyQt v5.11, so `test_expected_qtest_proxies` fails with that release.