### PR TITLE
Fix handling of ``QtInfoMsg`` objects during logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+3.0.1 (unreleased)
+------------------
+
+- Fix handling of ``QtInfoMsg`` objects during logging (`#225`_).
+  Thanks `@willsALMANJ`_ for the report.
+
+.. _#225: https://github.com/pytest-dev/pytest-qt/issues/225
+
+
 3.0.0 (2018-07-12)
 ------------------
 
@@ -496,3 +505,4 @@ First working version.
 .. _@rth: https://github.com/rth
 .. _@Sheeo: https://github.com/Sheeo
 .. _@The-Compiler: https://github.com/The-Compiler
+.. _@willsALMANJ: https://github.com/willsALMANJ

--- a/pytestqt/logging.py
+++ b/pytestqt/logging.py
@@ -241,6 +241,8 @@ class Record(object):
                 qt_api.QtCriticalMsg: 'QtCriticalMsg',
                 qt_api.QtFatalMsg: 'QtFatalMsg',
             }
+            if qt_api.QtInfoMsg is not None:
+                cls._type_name_map[qt_api.QtInfoMsg] = 'QtInfoMsg'
         return cls._type_name_map[msg_type]
 
     @classmethod

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -90,10 +90,13 @@ class _QtApi:
         self.Qt = QtCore.Qt
         self.QEvent = QtCore.QEvent
 
+        # qInfo is not exposed in PyQt5 and PySide2 bindings (#225)
+        self.qInfo = None
         self.qDebug = QtCore.qDebug
         self.qWarning = QtCore.qWarning
         self.qCritical = QtCore.qCritical
         self.qFatal = QtCore.qFatal
+        self.QtInfoMsg = getattr(QtCore, 'QtInfoMsg', None)
         self.QtDebugMsg = QtCore.QtDebugMsg
         self.QtWarningMsg = QtCore.QtWarningMsg
         self.QtCriticalMsg = QtCore.QtCriticalMsg

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -33,6 +33,8 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
             qt_api.qInstallMsgHandler(print_msg)
 
         def test_types():
+            # qInfo is not exposed by the bindings yet (#225)
+            # qt_api.qInfo('this is an INFO message')
             qt_api.qDebug('this is a DEBUG message')
             qt_api.qWarning('this is a WARNING message')
             qt_api.qCritical('this is a CRITICAL message')
@@ -47,6 +49,8 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
         if qt_log:
             res.stdout.fnmatch_lines([
                 '*-- Captured Qt messages --*',
+                # qInfo is not exposed by the bindings yet (#225)
+                # '*QtInfoMsg: this is an INFO message*',
                 '*QtDebugMsg: this is a DEBUG message*',
                 '*QtWarningMsg: this is a WARNING message*',
                 '*QtCriticalMsg: this is a CRITICAL message*',
@@ -54,6 +58,9 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
         else:
             res.stdout.fnmatch_lines([
                 '*-- Captured stderr call --*',
+                # qInfo is not exposed by the bindings yet (#225)
+                # '*QtInfoMsg: this is an INFO message*',
+                # 'this is an INFO message*',
                 'this is a DEBUG message*',
                 'this is a WARNING message*',
                 'this is a CRITICAL message*',


### PR DESCRIPTION
Fix #225