### PR TITLE
Show import error messages for Qt backends

### DIFF
--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -70,9 +70,14 @@ class _QtApi:
     def set_qt_api(self, api):
         self.pytest_qt_api = self._get_qt_api_from_env() or api or self._guess_qt_api()
         if not self.pytest_qt_api:  # pragma: no cover
-            errors = '\n'.join('  {}: {}'.format(module, reason)
-                               for module, reason in sorted(self._import_errors.items()))
-            msg = "pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed\n" + errors
+            errors = "\n".join(
+                "  {}: {}".format(module, reason)
+                for module, reason in sorted(self._import_errors.items())
+            )
+            msg = (
+                "pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed\n"
+                + errors
+            )
             raise RuntimeError(msg)
 
         _root_modules = {

--- a/pytestqt/qt_compat.py
+++ b/pytestqt/qt_compat.py
@@ -16,6 +16,10 @@ import os
 VersionTuple = namedtuple("VersionTuple", "qt_api, qt_api_version, runtime, compiled")
 
 
+def _import(name):
+    __import__(name)
+
+
 class _QtApi:
     """
     Interface to the underlying Qt API currently configured for pytest-qt.
@@ -45,7 +49,7 @@ class _QtApi:
     def _guess_qt_api(self):  # pragma: no cover
         def _can_import(name):
             try:
-                __import__(name)
+                _import(name)
                 return True
             except ImportError as e:
                 self._import_errors[name] = str(e)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -466,14 +466,16 @@ def test_importerror(monkeypatch):
     def _fake_import(name, *args):
         raise ImportError("Failed to import {}".format(name))
 
-    monkeypatch.delenv('PYTEST_QT_API', raising=False)
-    monkeypatch.setattr(qt_compat, '_import', _fake_import)
+    monkeypatch.delenv("PYTEST_QT_API", raising=False)
+    monkeypatch.setattr(qt_compat, "_import", _fake_import)
 
-    expected = ("pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed\n"
-                "  PyQt4.QtCore: Failed to import PyQt4.QtCore\n"
-                "  PyQt5.QtCore: Failed to import PyQt5.QtCore\n"
-                "  PySide.QtCore: Failed to import PySide.QtCore\n"
-                "  PySide2.QtCore: Failed to import PySide2.QtCore")
+    expected = (
+        "pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed\n"
+        "  PyQt4.QtCore: Failed to import PyQt4.QtCore\n"
+        "  PyQt5.QtCore: Failed to import PyQt5.QtCore\n"
+        "  PySide.QtCore: Failed to import PySide.QtCore\n"
+        "  PySide2.QtCore: Failed to import PySide2.QtCore"
+    )
 
     with pytest.raises(RuntimeError, match=expected):
         qt_api.set_qt_api(api=None)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -2,6 +2,7 @@ import weakref
 
 import pytest
 
+from pytestqt import qt_compat
 from pytestqt.qt_compat import qt_api
 
 
@@ -459,3 +460,20 @@ def test_qapp_args(testdir):
     )
     result = testdir.runpytest_subprocess()
     result.stdout.fnmatch_lines(["*= 1 passed in *"])
+
+
+def test_importerror(monkeypatch):
+    def _fake_import(name, *args):
+        raise ImportError("Failed to import {}".format(name))
+
+    monkeypatch.delenv('PYTEST_QT_API', raising=False)
+    monkeypatch.setattr(qt_compat, '_import', _fake_import)
+
+    expected = ("pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed\n"
+                "  PyQt4.QtCore: Failed to import PyQt4.QtCore\n"
+                "  PyQt5.QtCore: Failed to import PyQt5.QtCore\n"
+                "  PySide.QtCore: Failed to import PySide.QtCore\n"
+                "  PySide2.QtCore: Failed to import PySide2.QtCore")
+
+    with pytest.raises(RuntimeError, match=expected):
+        qt_api.set_qt_api(api=None)


### PR DESCRIPTION
This makes it easier to debug why importing failed.

I tried to write a test for this, but gave up because patching `__import__` causes funny issues in pytest itself when importing things late there...

```diff
diff --git a/tests/test_basics.py b/tests/test_basics.py
index 847dfde..7f03645 100644
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,3 +1,4 @@
+import sys
 import weakref
 
 import pytest
@@ -459,3 +460,25 @@ def test_qapp_args(testdir):
     )
     result = testdir.runpytest_subprocess()
     result.stdout.fnmatch_lines(["*= 1 passed in *"])
+
+
+def test_importerror(monkeypatch):
+    real_import = __import__
+
+    def _fake_import(name, *args):
+        if name not in ['PySide', 'PySide2', 'PyQt4', 'PyQt5']:
+            return real_import(name, *args)
+        import pdb; pdb.set_trace()
+        raise ImportError("Failed to import {}".format(name))
+
+    module = '__builtins__' if sys.version_info.major == 2 else 'builtins'
+    monkeypatch.setattr('{}.__import__'.format(module), _fake_import)
+
+    expected = ("pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed\n"
+                "  PyQt4.QtCore: Failed to import PyQt4\n"
+                "  PyQt5.QtCore: Failed to import PyQt5\n"
+                "  PySide.QtCore: Failed to import PySide\n"
+                "  PySide2.QtCore: No module named PySide2")
+
+    with pytest.raises(RuntimeError, match=expected):
+        qt_api.set_qt_api(api=None)
```

Here's how the output looks now:

```
INTERNALERROR> RuntimeError: pytest-qt requires either PySide, PySide2, PyQt4 or PyQt5 to be installed
INTERNALERROR>   PyQt4.QtCore: No module named 'PyQt4'
INTERNALERROR>   PyQt5.QtCore: No module named 'PyQt5'
INTERNALERROR>   PySide.QtCore: No module named 'PySide'
INTERNALERROR>   PySide2.QtCore: No module named 'PySide2'
```