### PR TITLE
Minor changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+3.0.3 (unreleased)
+------------------
+
+- Improve debugging output when no Qt wrapper was found.
+- Register the ``no_qt_log`` marker with pytest so ``--strict`` can be used.
+
 3.0.2 (2018-08-31)
 ------------------
 

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -204,6 +204,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "qt_log_ignore: overrides qt_log_ignore ini option."
     )
+    config.addinivalue_line(
+        "markers", "no_qt_log: Turn off Qt logging capture."
+    )
 
     if config.getoption("qt_log"):
         config.pluginmanager.register(QtLoggingPlugin(config), "_qt_logging")

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -204,9 +204,7 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "qt_log_ignore: overrides qt_log_ignore ini option."
     )
-    config.addinivalue_line(
-        "markers", "no_qt_log: Turn off Qt logging capture."
-    )
+    config.addinivalue_line("markers", "no_qt_log: Turn off Qt logging capture.")
 
     if config.getoption("qt_log"):
         config.pluginmanager.register(QtLoggingPlugin(config), "_qt_logging")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[tool:pytest]
+testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ universal = 1
 
 [tool:pytest]
 testpaths = tests
+addopts = --strict
+xfail_strict = true

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -18,7 +18,7 @@ fails_on_pyqt = pytest.mark.xfail(
         "keyEvent",
         "keyPress",
         "keyRelease",
-        fails_on_pyqt("keyToAscii"),
+        pytest.param("keyToAscii", marks=fails_on_pyqt),
         "mouseClick",
         "mouseDClick",
         "mouseMove",

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps=
     pyside2: pyside2
     pyqt5: pyqt5
 commands=
-    pytest tests
+    pytest {posargs}
 setenv=
     pyside2: PYTEST_QT_API=pyside2
     pyqt5: PYTEST_QT_API=pyqt5


### PR DESCRIPTION
- Fix a pytest deprecation warning in the testsuite
- Allow using posargs with tox
- Make pytest more strict for the testsuite
- Register `no_qt_log` marker with pytest
- Update the changelog for this and #234 
- ~~Fix typo (cherry-picked from #157)~~ took this one out again as I'm working on the callback blocker again and that would conflict.