### PR TITLE
Attempt to fix Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
       # used by ci-helpers
       - DEPS="pytest tox coveralls six"
       - MINICONDA_VERSION=latest
+      - DISPLAY=":99.0"
 
   matrix:
       - LINTING=1
@@ -41,6 +42,9 @@ install:
       sudo apt-get update
       sudo apt-get install -y xvfb herbstluftwm
 
+      # courtesy of https://github.com/astropy/ci-helpers/blob/master/travis/setup_conda_linux.sh
+      /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset
+
       # Setup miniconda
       wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh
       bash miniconda.sh -b -p $HOME/miniconda
@@ -48,8 +52,7 @@ install:
       conda config --add channels conda-forge
       conda config --set always_yes yes --set changeps1 no
       conda create -n test --quiet python=${PYTHON_VERSION} ${DEPS} ${PYQT_PACKAGE}
-      # pytest-xvfb installed via pip because not on conda-forge yet
-      source activate test && pip install -e . pytest-xvfb
+      source activate test && pip install -e .
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ dist: trusty
 env:
   global:
       # used by ci-helpers
-      - CONDA_CHANNELS=conda-forge SETUP_XVFB=true  DEPS="pytest tox coveralls six"
+      - DEPS="pytest tox coveralls six"
+      - MINICONDA_VERSION=latest
 
   matrix:
       - LINTING=1
@@ -41,9 +42,14 @@ install:
       sudo apt-get install -y xvfb herbstluftwm
 
       # Setup miniconda
-      git clone --depth 1 git://github.com/astropy/ci-helpers.git
-      CONDA_DEPENDENCIES="${DEPS} ${PYQT_PACKAGE}" source ci-helpers/travis/setup_conda.sh
-      source activate test && pip install -e .
+      wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh
+      bash miniconda.sh -b -p $HOME/miniconda
+      export PATH="$HOME/miniconda/bin:$PATH"
+      conda config --add channels conda-forge
+      conda config --set always_yes yes --set changeps1 no
+      conda create -n test --quiet python=${PYTHON_VERSION} ${DEPS} ${PYQT_PACKAGE}
+      # pytest-xvfb installed via pip because not on conda-forge yet
+      source activate test && pip install -e . pytest-xvfb
     fi
 
 before_script:


### PR DESCRIPTION
Manually configure miniconda on Travis and use pytest-xvfb

Our travis build started failing with errors like this for pyqt 4 and 5:

```
UnsatisfiableError: The following specifications were found to be in conflict:
  - pyqt
  - pyqt=4.*
```
  
This commit installs miniconda manually so we can have better control at
what is going on, and install pytest-xvfb to handle xvfb for us.