### PR TITLE
Add CallbackBlocker.assert_called_with()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+3.2.0 (unreleased)
+------------------
+
+- The ``CallbackBlocker`` returned by ``qtbot.waitCallback()`` now has a new
+  ``assert_called_with(...)`` convenience method.
+
 3.1.0 (2018-09-23)
 ------------------
 

--- a/docs/wait_callback.rst
+++ b/docs/wait_callback.rst
@@ -48,3 +48,10 @@ In the example above, we could check the result via:
 
        assert cb.args == [2]
        assert cb.kwargs == {}
+
+Instead of checking the arguments by hand, you can use ``.assert_called_with()``
+to make sure the callback was called with the given arguments:
+
+.. code-block:: python
+
+       cb.assert_called_with(2)

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -664,6 +664,15 @@ class CallbackBlocker(object):
         if not self.called and self.raising:
             raise TimeoutError("Callback wasn't called after %sms." % self.timeout)
 
+    def assert_called_with(self, *args, **kwargs):
+        """
+        Check that the callback was called with the same arguments as this
+        function.
+        """
+        assert self.called
+        assert self.args == list(args)
+        assert self.kwargs == kwargs
+
     def _quit_loop_by_timeout(self):
         try:
             self._cleanup()

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -1387,6 +1387,18 @@ class TestWaitCallback:
         assert callback.args == [23]
         assert callback.kwargs == {"answer": 42}
 
+    def test_assert_called_with(self, qtbot):
+        with qtbot.waitCallback() as callback:
+            callback(23, answer=42)
+        callback.assert_called_with(23, answer=42)
+
+    def test_assert_called_with_wrong(self, qtbot):
+        with qtbot.waitCallback() as callback:
+            callback(23, answer=42)
+
+        with pytest.raises(AssertionError):
+            callback.assert_called_with(23)
+
     def test_explicit(self, qtbot):
         blocker = qtbot.waitCallback()
         assert not blocker.called


### PR DESCRIPTION
When changing my testsuite to use `CallbackBlocker`, I noticed checking args and kwargs individually is as list/dict is a bit cumbersome.

The API is inspired by `unittest.mock`, but I don't think we need the other stuff (like `assert_called_once_with`).