### PR TITLE
Update Qt documentation link

### DIFF
--- a/pytestqt/qtbot.py
+++ b/pytestqt/qtbot.py
@@ -132,7 +132,7 @@ class QtBot(object):
         :param int delay: after the event, delay the test for this miliseconds (if > 0).
 
 
-    .. _QTest API: http://doc.qt.digia.com/4.8/qtest.html
+    .. _QTest API: http://doc.qt.io/qt-5/qtest.html
 
     """
 


### PR DESCRIPTION
This merge request updates the link to the QTest framework documentation as it has moved to doc.qt.io.