### PR TITLE
Bump minimum pytest version to 3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,9 @@
-3.2.3 (unreleased)
+3.3.0 (unreleased)
 ------------------
 
 - Improve message in uncaught exceptions by mentioning the Qt event loop instead of
   Qt virtual methods (`#255`_).
+- ``pytest-qt`` now requires ``pytest`` version >= 3.0.
 
 .. _#255: https://github.com/pytest-dev/pytest-qt/pull/255
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -28,7 +28,7 @@ Requirements
 
 Python 2.7 or later, including Python 3.4+.
 
-Requires pytest version 2.7 or later.
+Requires pytest version 3.0 or later.
 
 Works with either ``PyQt5``, ``PyQt4``, ``PySide`` or ``PySide2``, picking whichever
 is available on the system giving preference to the first one installed in

--- a/pytestqt/plugin.py
+++ b/pytestqt/plugin.py
@@ -42,7 +42,7 @@ def qapp_args():
     return []
 
 
-@pytest.yield_fixture(scope="session")
+@pytest.fixture(scope="session")
 def qapp(qapp_args):
     """
     Fixture that instantiates the QApplication instance that will be used by
@@ -55,9 +55,9 @@ def qapp(qapp_args):
     if app is None:
         global _qapp_instance
         _qapp_instance = qt_api.QApplication(qapp_args)
-        yield _qapp_instance
+        return _qapp_instance
     else:
-        yield app  # pragma: no cover
+        return app  # pragma: no cover
 
 
 # holds a global QApplication instance created in the qapp fixture; keeping
@@ -86,7 +86,7 @@ def qtlog(request):
         return _QtMessageCapture([])  # pragma: no cover
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def qtmodeltester(request):
     """
     Fixture used to create a ModelTester instance to test models.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name="pytest-qt",
     packages=["pytestqt"],
     entry_points={"pytest11": ["pytest-qt = pytestqt.plugin"]},
-    install_requires=["pytest>=2.7.0"],
+    install_requires=["pytest>=3.0.0"],
     extras_require={"doc": ["sphinx", "sphinx_rtd_theme"]},
     # metadata for upload to PyPI
     author="Bruno Oliveira",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def stop_watch():
     return StopWatch()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def timer():
     """
     Returns a Timer-like object which can be used to trigger signals and callbacks

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -170,7 +170,7 @@ def test_event_processing_before_and_after_teardown(testdir):
 
             return EventsQueue()
 
-        @pytest.yield_fixture
+        @pytest.fixture
         def fix(events_queue, qapp):
             assert events_queue.events == []
             yield
@@ -260,7 +260,7 @@ def test_widgets_closed_before_fixtures(testdir):
                 e.accept()
                 self.closed = True
 
-        @pytest.yield_fixture
+        @pytest.fixture
         def widget(qtbot):
             w = Widget()
             qtbot.add_widget(w)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -250,7 +250,7 @@ def test_exception_capture_on_fixture_setup_and_teardown(testdir, mode):
                     raise RuntimeError('event processed')
                 return True
 
-        @pytest.yield_fixture
+        @pytest.fixture
         def widget(qapp):
             w = MyWidget()
             {setup_code}

--- a/tests/test_wait_until.py
+++ b/tests/test_wait_until.py
@@ -38,7 +38,7 @@ def wait_4_ticks_callback(request, tick_counter):
         return check_ticks
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def tick_counter():
     """
     Returns an object which counts timer "ticks" periodically.


### PR DESCRIPTION
I was kinda suprised to still see yield_fixture used in the plugin, so I wanted
to get rid of that.