### PR TITLE
Add 'before_close_func' kwarg to qtbot.addWidget

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 18.6b4
+    rev: 19.10b0
     hooks:
     -   id: black
         args: [--safe, --quiet]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-3.3.0 (unreleased)
+3.3.0 (2019-12-07)
 ------------------
 
 - Improve message in uncaught exceptions by mentioning the Qt event loop instead of

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,11 @@
 
 - Improve message in uncaught exceptions by mentioning the Qt event loop instead of
   Qt virtual methods (`#255`_).
+
 - ``pytest-qt`` now requires ``pytest`` version >= 3.0.
+
+- ``qtbot.addWiget`` now supports an optional ``before_close_func`` keyword-only argument, which if given is a function
+  which is called before the widget is closed, with the widget as first argument.
 
 .. _#255: https://github.com/pytest-dev/pytest-qt/pull/255
 

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,15 @@ Pull requests are highly appreciated! If you
 can, include some tests that exercise the new code or test that a bug has been
 fixed, and make sure to include yourself in the contributors list. :)
 
+To prepare your environment, create a virtual environment and install ``pytest-qt`` in editable mode with ``dev``
+extras::
+
+    $ pip install --editable .[dev]
+
+After that install ``pre-commit`` for pre-commit checks::
+
+    $ pre-commit install
+
 Running tests
 -------------
 

--- a/pytestqt/wait_signal.py
+++ b/pytestqt/wait_signal.py
@@ -308,14 +308,22 @@ class MultiSignalBlocker(_AbstractSignalBlocker):
         super(MultiSignalBlocker, self).__init__(timeout, raising=raising)
         self._order = order
         self._check_params_callbacks = check_params_cbs
-        self._signals_emitted = []  # list of booleans, indicates whether the signal was already emitted
-        self._signals_map = {}  # maps from a unique Signal to a list of indices where to expect signal instance emits
-        self._signals = []  # list of all Signals (for compatibility with _AbstractSignalBlocker)
+        self._signals_emitted = (
+            []
+        )  # list of booleans, indicates whether the signal was already emitted
+        self._signals_map = (
+            {}
+        )  # maps from a unique Signal to a list of indices where to expect signal instance emits
+        self._signals = (
+            []
+        )  # list of all Signals (for compatibility with _AbstractSignalBlocker)
         self._slots = []  # list of slot functions
         self._signal_expected_index = 0  # only used when forcing order
         self._strict_order_violated = False
         self._actual_signal_and_args_at_violation = None
-        self._signal_names = {}  # maps from the unique Signal to the name of the signal (as string)
+        self._signal_names = (
+            {}
+        )  # maps from the unique Signal to the name of the signal (as string)
         self.all_signals_and_args = []  # list of SignalAndArgs instances
 
     def add_signals(self, signals):
@@ -422,14 +430,14 @@ class MultiSignalBlocker(_AbstractSignalBlocker):
             if not self._strict_order_violated:
                 # only do the check if the strict order has not been violated yet
                 self._strict_order_violated = (
-                    True
-                )  # assume the order has been violated this time
+                    True  # assume the order has been violated this time
+                )
                 if self._check_signal_matches_expected_index(unique_signal, *args):
                     self._signals_emitted[self._signal_expected_index] = True
                     self._signal_expected_index += 1
                     self._strict_order_violated = (
-                        False
-                    )  # order has not been violated after all!
+                        False  # order has not been violated after all!
+                    )
                 else:
                     if self._are_signal_names_available():
                         self._actual_signal_and_args_at_violation = SignalAndArgs(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
     packages=["pytestqt"],
     entry_points={"pytest11": ["pytest-qt = pytestqt.plugin"]},
     install_requires=["pytest>=3.0.0"],
-    extras_require={"doc": ["sphinx", "sphinx_rtd_theme"]},
+    extras_require={
+        "doc": ["sphinx", "sphinx_rtd_theme"],
+        "dev": ["pre-commit", "tox"],
+    },
     # metadata for upload to PyPI
     author="Bruno Oliveira",
     author_email="nicoddemus@gmail.com",

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv=DISPLAY XAUTHORITY USER USERNAME
 [testenv:linting]
 skip_install = True
 basepython = python3.6
-extras = dev
+deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv=DISPLAY XAUTHORITY USER USERNAME
 [testenv:linting]
 skip_install = True
 basepython = python3.6
-deps = pre-commit
+extras = dev
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [flake8]


### PR DESCRIPTION
This allows users and frameworks a chance to cleanup secondary testing resources before the widget gets effectively closed.