### PR TITLE
waitUntil: raise TimeoutError from AssertionError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 ------------------
 
 - ``pytest-qt`` now requires Python 3.6+.
+- ``waitUntil`` now raises a ``TimeoutError`` when a timeout occurs to make the cause of the timeout more explict (`#222`_). Thanks `@karlch`_ for the PR.
+
+.. _#222: https://github.com/pytest-dev/pytest-qt/pull/222
+.. _@karlch: https://github.com/karlch
 
 3.3.0 (2019-12-07)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,7 @@ Many thanks to:
 - Guilherme Quentel Melo (`@gqmelo <https://github.com/gqmelo>`_);
 - Francesco Montesano (`@montefra <https://github.com/montefra>`_);
 - Roman Yurchak (`@rth <https://github.com/rth>`_)
+- Christian Karl (`@karlch <https://github.com/karlch>`_)
 
 **Powered by**
 

--- a/docs/wait_until.rst
+++ b/docs/wait_until.rst
@@ -45,17 +45,21 @@ assertion:
 
 
 ``qtbot.waitUntil`` will periodically call ``check_label`` until it no longer raises
-``AssertionError`` or a timeout is reached. If a timeout is reached, the last assertion error
-re-raised and the test will fail:
+``AssertionError`` or a timeout is reached. If a timeout is reached, a
+:class:`qtbot.TimeoutError <TimeoutError>`
+is raised from the last assertion error and the test will fail:
 
 ::
 
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
         def check_label():
-    >       assert window.status.text() == 'Please input a number'
-    E       assert 'OK' == 'Please input a number'
+    >       assert window.status.text() == "Please input a number"
+    E       AssertionError: assert 'OK' == 'Please input a number'
     E         - OK
     E         + Please input a number
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    >       qtbot.waitUntil(check_label)
+    E       pytestqt.exceptions.TimeoutError: waitUntil timed out in 1000 miliseconds
 
 
 A second way to use ``qtbot.waitUntil`` is to pass a callback which returns ``True`` when the

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -516,12 +516,14 @@ class QtBot:
             elapsed_ms = elapsed * 1000
             return elapsed_ms > timeout
 
+        timeout_msg = f"waitUntil timed out in {timeout} miliseconds"
+
         while True:
             try:
                 result = callback()
-            except AssertionError:
+            except AssertionError as e:
                 if timed_out():
-                    raise
+                    raise TimeoutError(timeout_msg) from e
             else:
                 if result not in (None, True, False):
                     msg = "waitUntil() callback must return None, True or False, returned %r"
@@ -534,10 +536,8 @@ class QtBot:
                 # 'True/False' form
                 if result:
                     return
-                else:
-                    assert not timed_out(), (
-                        "waitUntil timed out in %s miliseconds" % timeout
-                    )
+                if timed_out():
+                    raise TimeoutError(timeout_msg)
             self.wait(10)
 
     wait_until = waitUntil  # pep-8 alias

--- a/tests/test_wait_until.py
+++ b/tests/test_wait_until.py
@@ -1,5 +1,7 @@
 import pytest
 
+from pytestqt.exceptions import TimeoutError
+
 
 def test_wait_until(qtbot, wait_4_ticks_callback, tick_counter):
     tick_counter.start(100)
@@ -9,7 +11,7 @@ def test_wait_until(qtbot, wait_4_ticks_callback, tick_counter):
 
 def test_wait_until_timeout(qtbot, wait_4_ticks_callback, tick_counter):
     tick_counter.start(200)
-    with pytest.raises(AssertionError):
+    with pytest.raises(TimeoutError):
         qtbot.waitUntil(wait_4_ticks_callback, 100)
     assert tick_counter.ticks < 4
 


### PR DESCRIPTION
This clearly shows that a timeout happened while keeping the initial error from the assertion as discussed in #222.

I was not quite sure how to update the docs, just let me know if something is missing there or anywhere else. Tests and linting pass locally with python 3.8 and PyQt5, I didn't test with any other versions.