### PR TITLE
Expose QtTest::keySequence

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
 
 - ``pytest-qt`` now requires Python 3.6+.
 - ``waitUntil`` now raises a ``TimeoutError`` when a timeout occurs to make the cause of the timeout more explict (`#222`_). Thanks `@karlch`_ for the PR.
+- The ``QtTest::keySequence`` method is now exposed (if available, with Qt >= 5.10).
 
 .. _#222: https://github.com/pytest-dev/pytest-qt/pull/222
 .. _@karlch: https://github.com/karlch

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -645,6 +645,10 @@ class QtBot:
             "mousePress",
             "mouseRelease",
         ]
+        if hasattr(qt_api.QtTest.QTest, "keySequence"):
+            # Added in Qt 5.10
+            method_names.append("keySequence")
+
         for method_name in method_names:
             method = create_qtest_proxy_method(method_name)
             if method is not None:

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -8,6 +8,10 @@ fails_on_pyqt = pytest.mark.xfail(
     qt_api.pytest_qt_api == "pyqt5", reason="fails on PyQt"
 )
 
+keysequence = pytest.mark.skipif(
+    not hasattr(qt_api.QtTest.QTest, "keySequence"), reason="needs Qt >= 5.10"
+)
+
 
 @pytest.mark.parametrize(
     "expected_method",
@@ -19,6 +23,7 @@ fails_on_pyqt = pytest.mark.xfail(
         "keyPress",
         "keyRelease",
         pytest.param("keyToAscii", marks=fails_on_pyqt),
+        pytest.param("keySequence", marks=keysequence),
         "mouseClick",
         "mouseDClick",
         "mouseMove",


### PR DESCRIPTION
It was added in Qt 5.10, this exposes it if it's available.