### PR TITLE
Bump up timeout for waitActive/waitExposed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@
 - ``waitUntil`` now raises a ``TimeoutError`` when a timeout occurs to make the cause of the timeout more explict (`#222`_). Thanks `@karlch`_ for the PR.
 - The ``QtTest::keySequence`` method is now exposed (if available, with Qt >= 5.10).
 - ``addWidget`` now enforces that its argument is a ``QWidget`` in order to display a clearer error when this isn't the case.
+- ``waitExposed`` and ``waitActive`` now have a default timeout of 5s instead of 1s, in order to match the default
+  timeouts Qt uses in the underlying QTest methods.
 
 .. _#222: https://github.com/pytest-dev/pytest-qt/pull/222
 .. _@karlch: https://github.com/karlch

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -172,7 +172,7 @@ class QtBot:
 
     add_widget = addWidget  # pep-8 alias
 
-    def waitActive(self, widget, timeout=1000):
+    def waitActive(self, widget, timeout=5000):
         """
         Context manager that waits for ``timeout`` milliseconds or until the window is active.
         If window is not exposed within ``timeout`` milliseconds, raise ``TimeoutError``.
@@ -204,7 +204,7 @@ class QtBot:
 
     wait_active = waitActive  # pep-8 alias
 
-    def waitExposed(self, widget, timeout=1000):
+    def waitExposed(self, widget, timeout=5000):
         """
         Context manager that waits for ``timeout`` milliseconds or until the window is exposed.
         If the window is not exposed within ``timeout`` milliseconds, raise ``TimeoutError``.


### PR DESCRIPTION
While the default 1s timeout matches other methods such as
waitSignal/waitUntil/..., it's much shorter than the default 5s timeout of the
underlying Qt methods. Thus, raise the default timeout to 5s to match what Qt
does.

Closes #297