### PR TITLE
RFC: Set application name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@
 - ``waitUntil`` now raises a ``TimeoutError`` when a timeout occurs to make the cause of the timeout more explict (`#222`_). Thanks `@karlch`_ for the PR.
 - The ``QtTest::keySequence`` method is now exposed (if available, with Qt >= 5.10).
 - ``addWidget`` now enforces that its argument is a ``QWidget`` in order to display a clearer error when this isn't the case.
+- New option ``qt_qapp_name`` can be used to set the name of the ``QApplication`` created by ``pytest-qt``, defaulting to ``"pytest-qt-qapp"``.
 - ``waitExposed`` and ``waitActive`` now have a default timeout of 5s instead of 1s, in order to match the default
   timeouts Qt uses in the underlying QTest methods.
 

--- a/docs/qapplication.rst
+++ b/docs/qapplication.rst
@@ -71,3 +71,15 @@ If your tests require access to app-level functions, like
     @pytest.fixture(scope="session")
     def qapp():
         yield CustomQApplication([])
+
+Setting a QApplication name
+---------------------------
+
+By default, pytest-qt set's the ``QApplication.applicationName()`` to
+``pytest-qt-qapp``. To use a custom name, you can set the ``qt_qapp_name``
+option in ``pytest.ini``:
+
+.. code-block:: ini
+
+    [pytest]
+    qt_qapp_name = frobnicate-tests

--- a/src/pytestqt/plugin.py
+++ b/src/pytestqt/plugin.py
@@ -43,7 +43,7 @@ def qapp_args():
 
 
 @pytest.fixture(scope="session")
-def qapp(qapp_args):
+def qapp(qapp_args, pytestconfig):
     """
     Fixture that instantiates the QApplication instance that will be used by
     the tests.
@@ -55,6 +55,8 @@ def qapp(qapp_args):
     if app is None:
         global _qapp_instance
         _qapp_instance = qt_api.QApplication(qapp_args)
+        name = pytestconfig.getini("qt_qapp_name")
+        _qapp_instance.setApplicationName(name)
         return _qapp_instance
     else:
         return app  # pragma: no cover
@@ -108,6 +110,9 @@ def pytest_addoption(parser):
     parser.addini(
         "qt_wait_signal_raising",
         "Default value for the raising parameter of qtbot.waitSignal (legacy alias)",
+    )
+    parser.addini(
+        "qt_qapp_name", "The Qt application name to use", default="pytest-qt-qapp"
     )
 
     default_log_fail = QtLoggingPlugin.LOG_FAIL_OPTIONS[0]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -21,6 +21,27 @@ def test_basics(qtbot):
     assert widget.windowTitle() == "W1"
 
 
+def test_qapp_default_name(qapp):
+    assert qapp.applicationName() == "pytest-qt-qapp"
+
+
+def test_qapp_name(testdir):
+    testdir.makepyfile(
+        """
+    def test_name(qapp):
+        assert qapp.applicationName() == "frobnicator"
+    """
+    )
+    testdir.makeini(
+        """
+        [pytest]
+        qt_qapp_name = frobnicator
+        """
+    )
+    res = testdir.runpytest_subprocess()
+    res.stdout.fnmatch_lines("*1 passed*")
+
+
 def test_key_events(qtbot, event_recorder):
     """
     Basic key events test.


### PR DESCRIPTION
When an application name is set, Qt uses it internally for e.g. getting
data/config locations:

    >>> QStandardPaths.writableLocation(QStandardPaths.DataLocation)
    '/home/user/.local/share'
    >>> qapp.setApplicationName('pytest-qt-qapp')
    >>> QStandardPaths.writableLocation(QStandardPaths.DataLocation)
    '/home/user/.local/share/pytest-qt-qapp'

That way, when an application accidentally writes into a data/cache/config
directory, it will be easier to find out (rather than those files just landing
somewhere outside an application directory).