### PR TITLE
Docs: Fix typo in logging.rst

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -49,7 +49,7 @@ Disabling Logging Capture
 -------------------------
 
 Qt logging capture can be disabled altogether by passing the ``--no-qt-log``
-to the command line, which will fallback to the default Qt bahavior of printing
+to the command line, which will fallback to the default Qt behavior of printing
 emitted messages directly to ``stderr``:
 
 .. code-block:: bash


### PR DESCRIPTION
Fixes a small typo I noticed when reading the docs: bahavior -> behavior.

Thanks again for this awesome project!