### PR TITLE
Allow unexact match of qabstractitemmodeltester.cpp

### DIFF
--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -350,7 +350,7 @@ def test_qt_tester_invalid(testdir):
             "test_qt_tester_invalid.py:*: Qt modeltester errors",
             "*-- Captured Qt messages --*",
             "* QtWarningMsg: FAIL! model->columnCount(QModelIndex()) >= 0 () returned FALSE "
-            "(qabstractitemmodeltester.cpp:*)",
+            "(*qabstractitemmodeltester.cpp:*)",
             "*-- Captured stdout call --*",
             "modeltest: Using Qt C++ tester",
             "*== 1 failed in * ==*",


### PR DESCRIPTION
fixes bug https://github.com/pytest-dev/pytest-qt/issues/314 and https://bugs.gentoo.org/738264
