### PR TITLE
Fix Qt 6 test failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [tool:pytest]
 testpaths = tests
-addopts = --strict
+addopts = --strict-markers --strict-config
 xfail_strict = true
 markers =
   filterwarnings: pytest's filterwarnings marker

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -623,7 +623,7 @@ class QtBot:
 
     @staticmethod
     def keyToAscii(key):
-        if qt_api.pytest_qt_api == "pyqt5":
+        if not hasattr(qt_api.QtTest.QTest, "keyToAscii"):
             raise NotImplementedError("This method isn't available on PyQt5.")
         qt_api.QtTest.QTest.keyToAscii(key)
 

--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -349,7 +349,7 @@ def test_qt_tester_invalid(testdir):
             "*__ test_ok __*",
             "test_qt_tester_invalid.py:*: Qt modeltester errors",
             "*-- Captured Qt messages --*",
-            "* QtWarningMsg: FAIL! model->columnCount(QModelIndex()) >= 0 () returned FALSE "
+            "*QtWarningMsg: FAIL! model->columnCount(QModelIndex()) >= 0 () returned FALSE "
             "(*qabstractitemmodeltester.cpp:*)",
             "*-- Captured stdout call --*",
             "modeltest: Using Qt C++ tester",

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -30,7 +30,7 @@ def test_expected_qtest_proxies(qtbot, expected_method):
     assert getattr(qtbot, expected_method).__name__ == expected_method
 
 
-@pytest.mark.skipif(qt_api.pytest_qt_api == "pyside2", reason="PyQt test only")
+@pytest.mark.skipif(qt_api.is_pyside, reason="PyQt test only")
 def test_keyToAscii_not_available_on_pyqt(testdir):
     """
     Test that qtbot.keyToAscii() is not available on PyQt5 and

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv=
     pyqt5: PYTEST_QT_API=pyqt5
     QT_QPA_PLATFORM=offscreen
 
-passenv=DISPLAY XAUTHORITY USER USERNAME
+passenv=DISPLAY XAUTHORITY USER USERNAME COLUMNS
 
 [testenv:linting]
 skip_install = True


### PR DESCRIPTION
Looks like the build [passed](https://github.com/pytest-dev/pytest-qt/runs/1764317110) in the PR (#330) but then [started failing](https://github.com/pytest-dev/pytest-qt/runs/2008980207) with the merge to master (996b9d617fd3585e43693744bb851acbed0fd1df).

The former used PySide6 6.0.0 while the latter used PySide6 6.0.1 - I suspect that broke those tests.