### PR TITLE
Support PyQt6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        qt-lib: [pyqt5, pyside2, pyside6]
+        qt-lib: [pyqt5, pyqt6, pyside2, pyside6]
         os: [ubuntu-20.04, windows-latest, macos-latest]
         include:
           - python-version: "3.6"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,10 @@
 ------------------
 
 - `PySide6 <https://pypi.org/project/PySide6>`__ is now supported. Thanks `@jensheilman`_ for the PR.
-- Support for Qt4 (i.e. ``PyQt4`` and ``PySide``) is now dropped.
+- `PyQt6 <https://pypi.org/project/PyQt6>`__ 6.1+ is now supported. Thanks `@The-Compiler`_ for the PR.
 - ``pytest-qt`` now requires Python 3.6+.
+- When using PyQt5, ``pytest-qt`` now requires PyQt5 5.11 or newer.
+- Support for Qt4 (i.e. ``PyQt4`` and ``PySide``) is now dropped.
 - ``waitUntil`` now raises a ``TimeoutError`` when a timeout occurs to make the cause of the timeout more explict (`#222`_). Thanks `@karlch`_ for the PR.
 - The ``QtTest::keySequence`` method is now exposed (if available, with Qt >= 5.10).
 - ``addWidget`` now enforces that its argument is a ``QWidget`` in order to display a clearer error when this isn't the case.

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ like key presses and mouse clicks:
         qtbot.addWidget(widget)
 
         # click in the Greet button and make sure it updates the appropriate label
-        qtbot.mouseClick(widget.button_greet, QtCore.Qt.LeftButton)
+        qtbot.mouseClick(widget.button_greet, QtCore.Qt.MouseButton.LeftButton)
 
         assert widget.greet_label.text() == "Hello!"
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ like key presses and mouse clicks:
         qtbot.addWidget(widget)
 
         # click in the Greet button and make sure it updates the appropriate label
-        qtbot.mouseClick(widget.button_greet, QtCore.Qt.MouseButton.LeftButton)
+        qtbot.mouseClick(widget.button_greet, qt_api.QtCore.Qt.MouseButton.LeftButton)
 
         assert widget.greet_label.text() == "Hello!"
 

--- a/src/pytestqt/logging.py
+++ b/src/pytestqt/logging.py
@@ -247,13 +247,12 @@ class Record:
         """
         if not getattr(cls, "_type_name_map", None):
             cls._type_name_map = {
-                qt_api.QtDebugMsg: "QtDebugMsg",
-                qt_api.QtWarningMsg: "QtWarningMsg",
-                qt_api.QtCriticalMsg: "QtCriticalMsg",
-                qt_api.QtFatalMsg: "QtFatalMsg",
+                qt_api.QtCore.QtMsgType.QtDebugMsg: "QtDebugMsg",
+                qt_api.QtCore.QtMsgType.QtWarningMsg: "QtWarningMsg",
+                qt_api.QtCore.QtMsgType.QtCriticalMsg: "QtCriticalMsg",
+                qt_api.QtCore.QtMsgType.QtFatalMsg: "QtFatalMsg",
+                qt_api.QtCore.QtMsgType.QtInfoMsg: "QtInfoMsg",
             }
-            if qt_api.QtInfoMsg is not None:
-                cls._type_name_map[qt_api.QtInfoMsg] = "QtInfoMsg"
         return cls._type_name_map[msg_type]
 
     @classmethod
@@ -264,13 +263,12 @@ class Record:
         """
         if not getattr(cls, "_log_type_name_map", None):
             cls._log_type_name_map = {
-                qt_api.QtDebugMsg: "DEBUG",
-                qt_api.QtWarningMsg: "WARNING",
-                qt_api.QtCriticalMsg: "CRITICAL",
-                qt_api.QtFatalMsg: "FATAL",
+                qt_api.QtCore.QtMsgType.QtDebugMsg: "DEBUG",
+                qt_api.QtCore.QtMsgType.QtWarningMsg: "WARNING",
+                qt_api.QtCore.QtMsgType.QtCriticalMsg: "CRITICAL",
+                qt_api.QtCore.QtMsgType.QtFatalMsg: "FATAL",
+                qt_api.QtCore.QtMsgType.QtInfoMsg: "INFO",
             }
-            if qt_api.QtInfoMsg is not None:
-                cls._log_type_name_map[qt_api.QtInfoMsg] = "INFO"
         return cls._log_type_name_map[msg_type]
 
     def matches_level(self, level):

--- a/src/pytestqt/modeltest.py
+++ b/src/pytestqt/modeltest.py
@@ -74,7 +74,7 @@ class ModelTester:
         elif not index.isValid():
             return "<invalid> (0x{:x})".format(id(index))
         else:
-            data = self._model.data(index, qt_api.QtCore.Qt.DisplayRole)
+            data = self._model.data(index, qt_api.QtCore.Qt.ItemDataRole.DisplayRole)
             return "{}/{} {!r} (0x{:x})".format(
                 index.row(),
                 index.column(),
@@ -196,7 +196,7 @@ class ModelTester:
         assert self._column_count(qt_api.QtCore.QModelIndex()) >= 0
         self._fetch_more(qt_api.QtCore.QModelIndex())
         flags = self._model.flags(qt_api.QtCore.QModelIndex())
-        assert flags == qt_api.QtCore.Qt.ItemIsDropEnabled or not flags
+        assert flags == qt_api.ItemFlag.ItemIsDropEnabled or not flags
         self._has_children(qt_api.QtCore.QModelIndex())
 
         has_row = self._model.hasIndex(0, 0)
@@ -454,22 +454,22 @@ class ModelTester:
         assert self._model.index(0, 0).isValid()
 
         types = [
-            (qt_api.QtCore.Qt.DisplayRole, (str,)),
-            (qt_api.QtCore.Qt.ToolTipRole, (str,)),
-            (qt_api.QtCore.Qt.StatusTipRole, (str,)),
-            (qt_api.QtCore.Qt.WhatsThisRole, (str,)),
-            (qt_api.QtCore.Qt.SizeHintRole, qt_api.QtCore.QSize),
-            (qt_api.QtCore.Qt.FontRole, qt_api.QtGui.QFont),
+            (qt_api.QtCore.Qt.ItemDataRole.DisplayRole, (str,)),
+            (qt_api.QtCore.Qt.ItemDataRole.ToolTipRole, (str,)),
+            (qt_api.QtCore.Qt.ItemDataRole.StatusTipRole, (str,)),
+            (qt_api.QtCore.Qt.ItemDataRole.WhatsThisRole, (str,)),
+            (qt_api.QtCore.Qt.ItemDataRole.SizeHintRole, qt_api.QtCore.QSize),
+            (qt_api.QtCore.Qt.ItemDataRole.FontRole, qt_api.QtGui.QFont),
             (
-                qt_api.QtCore.Qt.BackgroundRole,
+                qt_api.QtCore.Qt.ItemDataRole.BackgroundRole,
                 (qt_api.QtGui.QColor, qt_api.QtGui.QBrush),
             ),
             (
-                qt_api.QtCore.Qt.ForegroundRole,
+                qt_api.QtCore.Qt.ItemDataRole.ForegroundRole,
                 (qt_api.QtGui.QColor, qt_api.QtGui.QBrush),
             ),
             (
-                qt_api.QtCore.Qt.DecorationRole,
+                qt_api.QtCore.Qt.ItemDataRole.DecorationRole,
                 (
                     qt_api.QtGui.QPixmap,
                     qt_api.QtGui.QImage,
@@ -487,7 +487,7 @@ class ModelTester:
 
         # Check that the alignment is one we know about
         alignment = self._model.data(
-            self._model.index(0, 0), qt_api.QtCore.Qt.TextAlignmentRole
+            self._model.index(0, 0), qt_api.QtCore.Qt.ItemDataRole.TextAlignmentRole
         )
         if alignment is not None:
             try:
@@ -495,20 +495,20 @@ class ModelTester:
             except (TypeError, ValueError):
                 assert 0, "%r should be a TextAlignmentRole enum" % alignment
             mask = int(
-                qt_api.QtCore.Qt.AlignHorizontal_Mask
-                | qt_api.QtCore.Qt.AlignVertical_Mask
+                qt_api.AlignmentFlag.AlignHorizontal_Mask
+                | qt_api.AlignmentFlag.AlignVertical_Mask
             )
             assert alignment == alignment & mask
 
         # Check that the "check state" is one we know about.
         state = self._model.data(
-            self._model.index(0, 0), qt_api.QtCore.Qt.CheckStateRole
+            self._model.index(0, 0), qt_api.QtCore.Qt.ItemDataRole.CheckStateRole
         )
         assert state in [
             None,
-            qt_api.QtCore.Qt.Unchecked,
-            qt_api.QtCore.Qt.PartiallyChecked,
-            qt_api.QtCore.Qt.Checked,
+            qt_api.QtCore.Qt.CheckState.Unchecked,
+            qt_api.QtCore.Qt.CheckState.PartiallyChecked,
+            qt_api.QtCore.Qt.CheckState.Checked,
         ]
 
     def _on_rows_about_to_be_inserted(self, parent, start, end):
@@ -696,11 +696,14 @@ class ModelTester:
         assert bottom_right.column() < column_count
 
     def _on_header_data_changed(self, orientation, start, end):
-        assert orientation in [qt_api.QtCore.Qt.Horizontal, qt_api.QtCore.Qt.Vertical]
+        assert orientation in [
+            qt_api.Orientation.Horizontal,
+            qt_api.Orientation.Vertical,
+        ]
         assert start >= 0
         assert end >= 0
         assert start <= end
-        if orientation == qt_api.QtCore.Qt.Vertical:
+        if orientation == qt_api.Orientation.Vertical:
             item_count = self._model.rowCount()
         else:
             item_count = self._column_count()

--- a/src/pytestqt/modeltest.py
+++ b/src/pytestqt/modeltest.py
@@ -196,7 +196,7 @@ class ModelTester:
         assert self._column_count(qt_api.QtCore.QModelIndex()) >= 0
         self._fetch_more(qt_api.QtCore.QModelIndex())
         flags = self._model.flags(qt_api.QtCore.QModelIndex())
-        assert flags == qt_api.ItemFlag.ItemIsDropEnabled or not flags
+        assert flags == qt_api.QtCore.Qt.ItemFlag.ItemIsDropEnabled or not flags
         self._has_children(qt_api.QtCore.QModelIndex())
 
         has_row = self._model.hasIndex(0, 0)
@@ -495,8 +495,8 @@ class ModelTester:
             except (TypeError, ValueError):
                 assert 0, "%r should be a TextAlignmentRole enum" % alignment
             mask = int(
-                qt_api.AlignmentFlag.AlignHorizontal_Mask
-                | qt_api.AlignmentFlag.AlignVertical_Mask
+                qt_api.QtCore.Qt.AlignmentFlag.AlignHorizontal_Mask
+                | qt_api.QtCore.Qt.AlignmentFlag.AlignVertical_Mask
             )
             assert alignment == alignment & mask
 
@@ -697,13 +697,13 @@ class ModelTester:
 
     def _on_header_data_changed(self, orientation, start, end):
         assert orientation in [
-            qt_api.Orientation.Horizontal,
-            qt_api.Orientation.Vertical,
+            qt_api.QtCore.Qt.Orientation.Horizontal,
+            qt_api.QtCore.Qt.Orientation.Vertical,
         ]
         assert start >= 0
         assert end >= 0
         assert start <= end
-        if orientation == qt_api.Orientation.Vertical:
+        if orientation == qt_api.QtCore.Qt.Orientation.Vertical:
             item_count = self._model.rowCount()
         else:
             item_count = self._column_count()

--- a/src/pytestqt/plugin.py
+++ b/src/pytestqt/plugin.py
@@ -101,7 +101,9 @@ def qtmodeltester(request):
 
 
 def pytest_addoption(parser):
-    parser.addini("qt_api", 'Qt api version to use: "pyside6" , "pyside2", "pyqt5"')
+    parser.addini(
+        "qt_api", 'Qt api version to use: "pyside6" , "pyside2", "pyqt6", "pyqt5"'
+    )
     parser.addini("qt_no_exception_capture", "disable automatic exception capture")
     parser.addini(
         "qt_default_raising",

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -84,6 +84,8 @@ class _QtApi:
             )
             raise RuntimeError(msg)
 
+        # FIXME check minimum supported versions?
+
         _root_modules = {
             "pyside6": "PySide6",
             "pyside2": "PySide2",
@@ -168,17 +170,7 @@ class _QtApi:
             assert self.is_pyqt
             self.isdeleted = _import_module("sip").isdeleted
 
-        # PyQt6 only allows flag access via the flag type (usually plural),
-        # while PyQt5/PySide2/PySide6 only allow such access via the enum type
-        # (usually singular):
-        # https://www.riverbankcomputing.com/pipermail/pyqt/2021-March/043709.html
         if self.pytest_qt_api == "pyqt6":
-            self.AlignmentFlag = self.Qt.Alignment
-            self.Orientation = self.Qt.Orientations
-            self.MouseButton = self.Qt.MouseButtons
-            self.KeyboardModifier = self.Qt.KeyboardModifiers
-            self.ItemFlag = self.Qt.ItemFlags
-
             # exec was a keyword in Python 2, PyQt6 dropped the .exec_ alias but
             # PySide2/PySide6 still name it "exec_" only.
             self.QtCore.QCoreApplication.exec_ = (
@@ -190,12 +182,6 @@ class _QtApi:
             _QtWidgets.QDialog.exec_ = lambda _self, *args, **kwargs: _self.exec(
                 *args, **kwargs
             )
-        else:
-            self.AlignmentFlag = self.Qt.AlignmentFlag
-            self.Orientation = self.Qt.Orientation
-            self.MouseButton = self.Qt.MouseButton
-            self.KeyboardModifier = self.Qt.KeyboardModifier
-            self.ItemFlag = self.Qt.ItemFlag
 
     def get_versions(self):
         if self.pytest_qt_api == "pyside6":

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -209,7 +209,7 @@ class _QtApi:
                 self.QtCore.QT_VERSION_STR,
             )
 
-        assert False, self.pytest_qt_api
+        assert False, f"Internal error, unknown pytest_qt_api: {self.pytest_qt_api}"
 
 
 qt_api = _QtApi()

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -39,6 +39,7 @@ class _QtApi:
             if api not in (
                 "pyside6",
                 "pyside2",
+                "pyqt6",
                 "pyqt5",
             ):  # pragma: no cover
                 msg = "Invalid value for $PYTEST_QT_API: %s"
@@ -60,6 +61,8 @@ class _QtApi:
             return "pyside6"
         elif _can_import("PySide2.QtCore"):
             return "pyside2"
+        elif _can_import("PyQt6.QtCore"):
+            return "pyqt6"
         elif _can_import("PyQt5.QtCore"):
             return "pyqt5"
         return None
@@ -68,6 +71,7 @@ class _QtApi:
         self.pytest_qt_api = self._get_qt_api_from_env() or api or self._guess_qt_api()
 
         self.is_pyside = self.pytest_qt_api in ["pyside2", "pyside6"]
+        self.is_pyqt = self.pytest_qt_api in ["pyqt5", "pyqt6"]
 
         if not self.pytest_qt_api:  # pragma: no cover
             errors = "\n".join(
@@ -75,7 +79,7 @@ class _QtApi:
                 for module, reason in sorted(self._import_errors.items())
             )
             msg = (
-                "pytest-qt requires either PySide2, PySide6 or PyQt5 installed.\n"
+                "pytest-qt requires either PySide2, PySide6, PyQt5 or PyQt6 installed.\n"
                 + errors
             )
             raise RuntimeError(msg)
@@ -83,6 +87,7 @@ class _QtApi:
         _root_modules = {
             "pyside6": "PySide6",
             "pyside2": "PySide2",
+            "pyqt6": "PyQt6",
             "pyqt5": "PyQt5",
         }
         _root_module = _root_modules[self.pytest_qt_api]
@@ -109,11 +114,8 @@ class _QtApi:
         self.qWarning = QtCore.qWarning
         self.qCritical = QtCore.qCritical
         self.qFatal = QtCore.qFatal
-        self.QtInfoMsg = getattr(QtCore, "QtInfoMsg", None)
-        self.QtDebugMsg = QtCore.QtDebugMsg
-        self.QtWarningMsg = QtCore.QtWarningMsg
-        self.QtCriticalMsg = QtCore.QtCriticalMsg
-        self.QtFatalMsg = QtCore.QtFatalMsg
+
+        _QtWidgets = _import_module("QtWidgets")
 
         if self.is_pyside:
             self.Signal = QtCore.Signal
@@ -129,19 +131,17 @@ class _QtApi:
             self.QAbstractListModel = QtCore.QAbstractListModel
             self.QAbstractTableModel = QtCore.QAbstractTableModel
 
-            _QtWidgets = _import_module("QtWidgets")
             self.QApplication = _QtWidgets.QApplication
             self.QWidget = _QtWidgets.QWidget
             self.QLineEdit = _QtWidgets.QLineEdit
             self.qInstallMessageHandler = QtCore.qInstallMessageHandler
 
             self.QSortFilterProxyModel = QtCore.QSortFilterProxyModel
-        elif self.pytest_qt_api == "pyqt5":
+        elif self.is_pyqt:
             self.Signal = QtCore.pyqtSignal
             self.Slot = QtCore.pyqtSlot
             self.Property = QtCore.pyqtProperty
 
-            _QtWidgets = _import_module("QtWidgets")
             self.QApplication = _QtWidgets.QApplication
             self.QWidget = _QtWidgets.QWidget
             self.qInstallMessageHandler = QtCore.qInstallMessageHandler
@@ -153,6 +153,49 @@ class _QtApi:
             self.QStandardItemModel = QtGui.QStandardItemModel
             self.QAbstractListModel = QtCore.QAbstractListModel
             self.QAbstractTableModel = QtCore.QAbstractTableModel
+        else:
+            assert False, "Expected either is_pyqt or is_pyside"
+
+        if self.pytest_qt_api == "pyside2":
+            import shiboken2
+
+            self.isdeleted = lambda obj: not shiboken2.isValid(obj)
+        elif self.pytest_qt_api == "pyside6":
+            import shiboken6
+
+            self.isdeleted = lambda obj: not shiboken6.isValid(obj)
+        else:
+            assert self.is_pyqt
+            self.isdeleted = _import_module("sip").isdeleted
+
+        # PyQt6 only allows flag access via the flag type (usually plural),
+        # while PyQt5/PySide2/PySide6 only allow such access via the enum type
+        # (usually singular):
+        # https://www.riverbankcomputing.com/pipermail/pyqt/2021-March/043709.html
+        if self.pytest_qt_api == "pyqt6":
+            self.AlignmentFlag = self.Qt.Alignment
+            self.Orientation = self.Qt.Orientations
+            self.MouseButton = self.Qt.MouseButtons
+            self.KeyboardModifier = self.Qt.KeyboardModifiers
+            self.ItemFlag = self.Qt.ItemFlags
+
+            # exec was a keyword in Python 2, PyQt6 dropped the .exec_ alias but
+            # PySide2/PySide6 still name it "exec_" only.
+            self.QtCore.QCoreApplication.exec_ = (
+                lambda _self, *args, **kwargs: _self.exec(*args, **kwargs)
+            )
+            self.QtCore.QEventLoop.exec_ = lambda _self, *args, **kwargs: _self.exec(
+                *args, **kwargs
+            )
+            _QtWidgets.QDialog.exec_ = lambda _self, *args, **kwargs: _self.exec(
+                *args, **kwargs
+            )
+        else:
+            self.AlignmentFlag = self.Qt.AlignmentFlag
+            self.Orientation = self.Qt.Orientation
+            self.MouseButton = self.Qt.MouseButton
+            self.KeyboardModifier = self.Qt.KeyboardModifier
+            self.ItemFlag = self.Qt.ItemFlag
 
     def get_versions(self):
         if self.pytest_qt_api == "pyside6":
@@ -163,7 +206,6 @@ class _QtApi:
             return VersionTuple(
                 "PySide6", version, self.QtCore.qVersion(), self.QtCore.__version__
             )
-            pass
         elif self.pytest_qt_api == "pyside2":
             import PySide2
 
@@ -172,13 +214,22 @@ class _QtApi:
             return VersionTuple(
                 "PySide2", version, self.QtCore.qVersion(), self.QtCore.__version__
             )
-        else:
+        elif self.pytest_qt_api == "pyqt6":
+            return VersionTuple(
+                "PyQt6",
+                self.QtCore.PYQT_VERSION_STR,
+                self.QtCore.qVersion(),
+                self.QtCore.QT_VERSION_STR,
+            )
+        elif self.pytest_qt_api == "pyqt5":
             return VersionTuple(
                 "PyQt5",
                 self.QtCore.PYQT_VERSION_STR,
                 self.QtCore.qVersion(),
                 self.QtCore.QT_VERSION_STR,
             )
+
+        assert False, self.pytest_qt_api
 
 
 qt_api = _QtApi()

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -170,18 +170,12 @@ class _QtApi:
             assert self.is_pyqt
             self.isdeleted = _import_module("sip").isdeleted
 
+    def exec(self, obj, *args, **kwargs):
         if self.pytest_qt_api == "pyqt6":
             # exec was a keyword in Python 2, PyQt6 dropped the .exec_ alias but
             # PySide2/PySide6 still name it "exec_" only.
-            self.QtCore.QCoreApplication.exec_ = (
-                lambda _self, *args, **kwargs: _self.exec(*args, **kwargs)
-            )
-            self.QtCore.QEventLoop.exec_ = lambda _self, *args, **kwargs: _self.exec(
-                *args, **kwargs
-            )
-            _QtWidgets.QDialog.exec_ = lambda _self, *args, **kwargs: _self.exec(
-                *args, **kwargs
-            )
+            return obj.exec(*args, **kwargs)
+        return obj.exec_(*args, **kwargs)
 
     def get_versions(self):
         if self.pytest_qt_api == "pyside6":

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -84,8 +84,6 @@ class _QtApi:
             )
             raise RuntimeError(msg)
 
-        # FIXME check minimum supported versions?
-
         _root_modules = {
             "pyside6": "PySide6",
             "pyside2": "PySide2",
@@ -103,6 +101,8 @@ class _QtApi:
         self.QtTest = _import_module("QtTest")
         self.Qt = QtCore.Qt
         self.QEvent = QtCore.QEvent
+
+        self._check_qt_api_version()
 
         # qInfo is not exposed in PySide2/6 (#232)
         if hasattr(QtCore, "QMessageLogger"):
@@ -169,6 +169,20 @@ class _QtApi:
         else:
             assert self.is_pyqt
             self.isdeleted = _import_module("sip").isdeleted
+
+    def _check_qt_api_version(self):
+        if not self.is_pyqt:
+            # We support all PySide versions
+            return
+
+        if self.QtCore.PYQT_VERSION == 0x060000:  # 6.0.0
+            raise RuntimeError(
+                "PyQt 6.0 is not supported by pytest-qt, use 6.1+ instead."
+            )
+        elif self.QtCore.PYQT_VERSION < 0x050B00:  # 5.11.0
+            raise RuntimeError(
+                "PyQt < 5.11 is not supported by pytest-qt, use 5.11+ instead."
+            )
 
     def exec(self, obj, *args, **kwargs):
         if self.pytest_qt_api == "pyqt6":

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -113,15 +113,15 @@ class QtBot:
         :param Qt.MouseButton button: flags OR'ed together representing the button pressed.
             Possible flags are:
 
-            * ``Qt.NoButton``: The button state does not refer to any button
+            * ``Qt.MouseButton.NoButton``: The button state does not refer to any button
               (see QMouseEvent.button()).
-            * ``Qt.LeftButton``: The left button is pressed, or an event refers to the left button.
+            * ``Qt.MouseButton.LeftButton``: The left button is pressed, or an event refers to the left button.
               (The left button may be the right button on left-handed mice.)
-            * ``Qt.RightButton``: The right button.
-            * ``Qt.MidButton``: The middle button.
-            * ``Qt.MiddleButton``: The middle button.
-            * ``Qt.XButton1``: The first X button.
-            * ``Qt.XButton2``: The second X button.
+            * ``Qt.MouseButton.RightButton``: The right button.
+            * ``Qt.MouseButton.MidButton``: The middle button.
+            * ``Qt.MouseButton.MiddleButton``: The middle button.
+            * ``Qt.MouseButton.XButton1``: The first X button.
+            * ``Qt.MouseButton.XButton2``: The second X button.
 
         :param Qt.KeyboardModifier modifier: flags OR'ed together representing other modifier keys
             also pressed. See `keyboard modifiers`_.

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -265,7 +265,7 @@ class QtBot:
             if widget is not None:
                 widget_and_visibility.append((widget, widget.isVisible()))
 
-        qt_api.QApplication.instance().exec_()
+        qt_api.exec(qt_api.QApplication.instance())
 
         for widget, visible in widget_and_visibility:
             widget.setVisible(visible)

--- a/src/pytestqt/wait_signal.py
+++ b/src/pytestqt/wait_signal.py
@@ -48,7 +48,7 @@ class _AbstractSignalBlocker:
             self._timer.start()
 
         if self.timeout != 0:
-            self._loop.exec_()
+            qt_api.exec(self._loop)
 
         if not self.signal_triggered and self.raising:
             raise TimeoutError(self._timeout_message)
@@ -666,7 +666,7 @@ class CallbackBlocker:
         if self._timer is not None:
             self._timer.timeout.connect(self._quit_loop_by_timeout)
             self._timer.start()
-        self._loop.exec_()
+        qt_api.exec(self._loop)
         if not self.called and self.raising:
             raise TimeoutError("Callback wasn't called after %sms." % self.timeout)
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -77,22 +77,22 @@ def test_mouse_events(qtbot, event_recorder):
 
     event_recorder.registerEvent(qt_api.QtGui.QMouseEvent, extract)
 
-    qtbot.mousePress(event_recorder, qt_api.MouseButton.LeftButton)
+    qtbot.mousePress(event_recorder, qt_api.QtCore.Qt.MouseButton.LeftButton)
     assert event_recorder.event_data == (
         qt_api.QEvent.Type.MouseButtonPress,
-        qt_api.MouseButton.LeftButton,
-        qt_api.KeyboardModifier.NoModifier,
+        qt_api.QtCore.Qt.MouseButton.LeftButton,
+        qt_api.QtCore.Qt.KeyboardModifier.NoModifier,
     )
 
     qtbot.mousePress(
         event_recorder,
-        qt_api.MouseButton.RightButton,
-        qt_api.KeyboardModifier.AltModifier,
+        qt_api.QtCore.Qt.MouseButton.RightButton,
+        qt_api.QtCore.Qt.KeyboardModifier.AltModifier,
     )
     assert event_recorder.event_data == (
         qt_api.QEvent.Type.MouseButtonPress,
-        qt_api.MouseButton.RightButton,
-        qt_api.KeyboardModifier.AltModifier,
+        qt_api.QtCore.Qt.MouseButton.RightButton,
+        qt_api.QtCore.Qt.KeyboardModifier.AltModifier,
     )
 
 
@@ -161,7 +161,6 @@ def test_widget_kept_as_weakref(qtbot):
     assert widget() is None
 
 
-@pytest.mark.skipif(qt_api.pytest_qt_api == "pyqt6", reason="FIXME segfaults")
 def test_event_processing_before_and_after_teardown(testdir):
     """
     Make sure events are processed before and after fixtures are torn down.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 
 from pytestqt.exceptions import capture_exceptions, format_captured_exceptions
-from pytestqt.qt_compat import qt_api
 
 
 @pytest.mark.parametrize("raise_error", [False, True])
@@ -122,7 +121,7 @@ def test_no_capture(testdir, no_capture_by_marker):
         def test_widget(qtbot):
             w = MyWidget()
             qtbot.addWidget(w)
-            qtbot.mouseClick(w, qt_api.MouseButton.LeftButton)
+            qtbot.mouseClick(w, qt_api.QtCore.Qt.MouseButton.LeftButton)
     """.format(
             marker_code=marker_code
         )
@@ -162,7 +161,6 @@ def test_no_capture_preserves_custom_excepthook(testdir):
     res.stdout.fnmatch_lines(["*2 passed*"])
 
 
-@pytest.mark.skipif(qt_api.pytest_qt_api == "pyqt6", reason="FIXME aborts")
 def test_exception_capture_on_call(testdir):
     """
     Exceptions should also be captured during test execution.
@@ -222,7 +220,6 @@ def test_exception_capture_on_widget_close(testdir):
 
 
 @pytest.mark.parametrize("mode", ["setup", "teardown"])
-@pytest.mark.skipif(qt_api.pytest_qt_api == "pyqt6", reason="FIXME aborts")
 def test_exception_capture_on_fixture_setup_and_teardown(testdir, mode):
     """
     Setup/teardown exception capturing as early/late as possible to catch
@@ -337,7 +334,6 @@ def test_capture_exceptions_qtbot_context_manager(testdir):
     result.stdout.fnmatch_lines(["*1 passed*"])
 
 
-@pytest.mark.skipif(qt_api.pytest_qt_api == "pyqt6", reason="FIXME aborts")
 def test_exceptions_to_stderr(qapp, capsys):
     """
     Exceptions should still be reported to stderr.
@@ -364,7 +360,6 @@ def test_exceptions_to_stderr(qapp, capsys):
     condition=sys.version_info[:2] == (3, 4),
     reason="failing in Python 3.4, which is about to be dropped soon anyway",
 )
-@pytest.mark.skipif(qt_api.pytest_qt_api == "pyqt6", reason="FIXME aborts")
 def test_exceptions_dont_leak(testdir):
     """
     Ensure exceptions are cleared when an exception occurs and don't leak (#187).

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -80,7 +80,7 @@ def test_qinfo(qtlog):
 
     qt_api.qInfo("this is an INFO message")
     records = [(m.type, m.message.strip()) for m in qtlog.records]
-    assert records == [(qt_api.QtInfoMsg, "this is an INFO message")]
+    assert records == [(qt_api.QtCore.QtMsgType.QtInfoMsg, "this is an INFO message")]
 
 
 def test_qtlog_fixture(qtlog):
@@ -93,9 +93,9 @@ def test_qtlog_fixture(qtlog):
     qt_api.qCritical("this is a CRITICAL message")
     records = [(m.type, m.message.strip()) for m in qtlog.records]
     assert records == [
-        (qt_api.QtDebugMsg, "this is a DEBUG message"),
-        (qt_api.QtWarningMsg, "this is a WARNING message"),
-        (qt_api.QtCriticalMsg, "this is a CRITICAL message"),
+        (qt_api.QtCore.QtMsgType.QtDebugMsg, "this is a DEBUG message"),
+        (qt_api.QtCore.QtMsgType.QtWarningMsg, "this is a WARNING message"),
+        (qt_api.QtCore.QtMsgType.QtCriticalMsg, "this is a CRITICAL message"),
     ]
     # `records` attribute is read-only
     with pytest.raises(AttributeError):
@@ -516,7 +516,7 @@ def test_context_none(testdir):
         def test_foo(request):
             log_capture = request.node.qt_log_capture
             context = log_capture._Context(None, None, 0, None)
-            log_capture._handle_with_context(qt_api.QtWarningMsg,
+            log_capture._handle_with_context(qt_api.QtCore.QtMsgType.QtWarningMsg,
                                              context, "WARNING message")
             assert 0
         """

--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -97,8 +97,8 @@ def test_broken_types(check_model, broken_role):
 @pytest.mark.parametrize(
     "role_value, should_pass",
     [
-        (qt_api.AlignmentFlag.AlignLeft, True),
-        (qt_api.AlignmentFlag.AlignRight, True),
+        (qt_api.QtCore.Qt.AlignmentFlag.AlignLeft, True),
+        (qt_api.QtCore.Qt.AlignmentFlag.AlignRight, True),
         (0xFFFFFF, False),
         ("foo", False),
         (object(), False),
@@ -135,8 +135,8 @@ def test_header_handling(check_model):
 
         def set_header_text(self, header):
             self._header_text = header
-            self.headerDataChanged.emit(qt_api.Orientation.Vertical, 0, 0)
-            self.headerDataChanged.emit(qt_api.Orientation.Horizontal, 0, 0)
+            self.headerDataChanged.emit(qt_api.QtCore.Qt.Orientation.Vertical, 0, 0)
+            self.headerDataChanged.emit(qt_api.QtCore.Qt.Orientation.Horizontal, 0, 0)
 
         def headerData(
             self, section, orientation, role=qt_api.QtCore.Qt.ItemDataRole.DisplayRole
@@ -217,7 +217,7 @@ def test_changing_model_data(qtmodeltester):
 
 @pytest.mark.parametrize(
     "orientation",
-    [qt_api.Orientation.Horizontal, qt_api.Orientation.Vertical],
+    [qt_api.QtCore.Qt.Orientation.Horizontal, qt_api.QtCore.Qt.Orientation.Vertical],
 )
 def test_changing_model_header_data(qtmodeltester, orientation):
     model = qt_api.QStandardItemModel()

--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.usefixtures("qtbot")
 
 
 class BasicModel(qt_api.QtCore.QAbstractItemModel):
-    def data(self, index, role=qt_api.QtCore.Qt.DisplayRole):
+    def data(self, index, role=qt_api.QtCore.Qt.ItemDataRole.DisplayRole):
         return None
 
     def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
@@ -57,15 +57,15 @@ def test_sort_filter_proxy_model(qtmodeltester):
 @pytest.mark.parametrize(
     "broken_role",
     [
-        qt_api.QtCore.Qt.ToolTipRole,
-        qt_api.QtCore.Qt.StatusTipRole,
-        qt_api.QtCore.Qt.WhatsThisRole,
-        qt_api.QtCore.Qt.SizeHintRole,
-        qt_api.QtCore.Qt.FontRole,
-        qt_api.QtCore.Qt.BackgroundRole,
-        qt_api.QtCore.Qt.ForegroundRole,
-        qt_api.QtCore.Qt.TextAlignmentRole,
-        qt_api.QtCore.Qt.CheckStateRole,
+        qt_api.QtCore.Qt.ItemDataRole.ToolTipRole,
+        qt_api.QtCore.Qt.ItemDataRole.StatusTipRole,
+        qt_api.QtCore.Qt.ItemDataRole.WhatsThisRole,
+        qt_api.QtCore.Qt.ItemDataRole.SizeHintRole,
+        qt_api.QtCore.Qt.ItemDataRole.FontRole,
+        qt_api.QtCore.Qt.ItemDataRole.BackgroundRole,
+        qt_api.QtCore.Qt.ItemDataRole.ForegroundRole,
+        qt_api.QtCore.Qt.ItemDataRole.TextAlignmentRole,
+        qt_api.QtCore.Qt.ItemDataRole.CheckStateRole,
     ],
 )
 def test_broken_types(check_model, broken_role):
@@ -82,7 +82,9 @@ def test_broken_types(check_model, broken_role):
                 return 0
 
         def data(
-            self, index=qt_api.QtCore.QModelIndex(), role=qt_api.QtCore.Qt.DisplayRole
+            self,
+            index=qt_api.QtCore.QModelIndex(),
+            role=qt_api.QtCore.Qt.ItemDataRole.DisplayRole,
         ):
             if role == broken_role:
                 return object()  # This will fail the type check for any role
@@ -95,8 +97,8 @@ def test_broken_types(check_model, broken_role):
 @pytest.mark.parametrize(
     "role_value, should_pass",
     [
-        (qt_api.QtCore.Qt.AlignLeft, True),
-        (qt_api.QtCore.Qt.AlignRight, True),
+        (qt_api.AlignmentFlag.AlignLeft, True),
+        (qt_api.AlignmentFlag.AlignRight, True),
         (0xFFFFFF, False),
         ("foo", False),
         (object(), False),
@@ -112,11 +114,13 @@ def test_data_alignment(role_value, should_pass, check_model):
             return 1 if parent == qt_api.QtCore.QModelIndex() else 0
 
         def data(
-            self, index=qt_api.QtCore.QModelIndex(), role=qt_api.QtCore.Qt.DisplayRole
+            self,
+            index=qt_api.QtCore.QModelIndex(),
+            role=qt_api.QtCore.Qt.ItemDataRole.DisplayRole,
         ):
-            if role == qt_api.QtCore.Qt.TextAlignmentRole:
+            if role == qt_api.QtCore.Qt.ItemDataRole.TextAlignmentRole:
                 return role_value
-            elif role == qt_api.QtCore.Qt.DisplayRole:
+            elif role == qt_api.QtCore.Qt.ItemDataRole.DisplayRole:
                 if index == self.index(0, 0):
                     return "Hello"
             return None
@@ -131,16 +135,23 @@ def test_header_handling(check_model):
 
         def set_header_text(self, header):
             self._header_text = header
-            self.headerDataChanged.emit(qt_api.QtCore.Qt.Vertical, 0, 0)
-            self.headerDataChanged.emit(qt_api.QtCore.Qt.Horizontal, 0, 0)
+            self.headerDataChanged.emit(qt_api.Orientation.Vertical, 0, 0)
+            self.headerDataChanged.emit(qt_api.Orientation.Horizontal, 0, 0)
 
-        def headerData(self, section, orientation, role=qt_api.QtCore.Qt.DisplayRole):
+        def headerData(
+            self, section, orientation, role=qt_api.QtCore.Qt.ItemDataRole.DisplayRole
+        ):
             return self._header_text
 
         def data(
-            self, index=qt_api.QtCore.QModelIndex(), role=qt_api.QtCore.Qt.DisplayRole
+            self,
+            index=qt_api.QtCore.QModelIndex(),
+            role=qt_api.QtCore.Qt.ItemDataRole.DisplayRole,
         ):
-            if role == qt_api.QtCore.Qt.DisplayRole and index == self.index(0, 0):
+            if (
+                role == qt_api.QtCore.Qt.ItemDataRole.DisplayRole
+                and index == self.index(0, 0)
+            ):
                 return "Contents"
             return None
 
@@ -205,7 +216,8 @@ def test_changing_model_data(qtmodeltester):
 
 
 @pytest.mark.parametrize(
-    "orientation", [qt_api.QtCore.Qt.Horizontal, qt_api.QtCore.Qt.Vertical]
+    "orientation",
+    [qt_api.Orientation.Horizontal, qt_api.Orientation.Vertical],
 )
 def test_changing_model_header_data(qtmodeltester, orientation):
     model = qt_api.QStandardItemModel()
@@ -322,7 +334,7 @@ def test_qt_tester_invalid(testdir):
 
 
         class Model(qt_api.QtCore.QAbstractItemModel):
-            def data(self, index, role=qt_api.QtCore.Qt.DisplayRole):
+            def data(self, index, role=qt_api.QtCore.Qt.ItemDataRole.DisplayRole):
                 return None
 
             def rowCount(self, parent=qt_api.QtCore.QModelIndex()):

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -45,7 +45,7 @@ def test_keyToAscii_not_available_on_pyqt(testdir):
             widget = qt_api.QWidget()
             qtbot.add_widget(widget)
             with pytest.raises(NotImplementedError):
-                qtbot.keyToAscii(qt_api.Qt.Key_Escape)
+                qtbot.keyToAscii(qt_api.Qt.Key.Key_Escape)
         """
     )
     result = testdir.runpytest()

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -376,10 +376,6 @@ def test_wait_signals_invalid_strict_parameter(qtbot, signaller):
 
 def test_destroyed(qtbot):
     """Test that waitSignal works with the destroyed signal (#82)."""
-    if qt_api.is_pyside:
-        pytest.skip("test depends on sip")
-
-    import sip
 
     class Obj(qt_api.QtCore.QObject):
         pass
@@ -388,7 +384,7 @@ def test_destroyed(qtbot):
     with qtbot.waitSignal(obj.destroyed):
         obj.deleteLater()
 
-    assert sip.isdeleted(obj)
+    assert qt_api.isdeleted(obj)
 
 
 class TestArgs:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-pyqt5, py{36,37,38}-pyside2, py{37,38}-pyside6, linting
+envlist = py{36,37,38}-pyqt5, py{36,37,38}-pyside2, py{37,38}-pyside6, py{36,37,38}-pyqt6, linting
 
 [testenv]
 deps=
@@ -7,12 +7,14 @@ deps=
     pyside6: pyside6
     pyside2: pyside2
     pyqt5: pyqt5
+    pyqt6: pyqt6
 commands=
     pytest {posargs}
 setenv=
     pyside6: PYTEST_QT_API=pyside6
     pyside2: PYTEST_QT_API=pyside2
     pyqt5: PYTEST_QT_API=pyqt5
+    pyqt6: PYTEST_QT_API=pyqt6
     QT_QPA_PLATFORM=offscreen
 
 passenv=DISPLAY XAUTHORITY USER USERNAME COLUMNS


### PR DESCRIPTION
Still a couple of issues (marked as FIXME for now), but wanted to get some feedback.

cc @jensheilman

Note that with the scoped enum access, we're dropping support for PyQt5 < 5.11. I think that's fine, given that 5.11 has been released in July 2018. I haven't checked yet how far back scoped enum access support in PySide2 goes, though.