### PR TITLE
Force garbage collection after each test

### DIFF
--- a/src/pytestqt/plugin.py
+++ b/src/pytestqt/plugin.py
@@ -1,3 +1,4 @@
+import gc
 import warnings
 
 import pytest
@@ -42,7 +43,7 @@ def qapp_args():
     return []
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def qapp(qapp_args, pytestconfig):
     """
     Fixture that instantiates the QApplication instance that will be used by
@@ -57,9 +58,10 @@ def qapp(qapp_args, pytestconfig):
         _qapp_instance = qt_api.QApplication(qapp_args)
         name = pytestconfig.getini("qt_qapp_name")
         _qapp_instance.setApplicationName(name)
-        return _qapp_instance
+        yield _qapp_instance
     else:
-        return app  # pragma: no cover
+        yield app  # pragma: no cover
+    gc.collect()
 
 
 # holds a global QApplication instance created in the qapp fixture; keeping


### PR DESCRIPTION
This solves the problem that widgets opened during a test are kept alive in the global QApplication instance, which can be tested by `assert []==qapp.topLevelWidgets()` at the beginning of the second, third, etc. test after the first test opens widgets.

It does require the functional change to the `qapp` fixture scope from `session` to `function`. I don't know if that would be considered breaking or not.