### PR TITLE
Clean up old qt_compat aliases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,9 @@
   implementations. This makes subclasses work as expected, instead of having to
   duplicate the assignment. Thanks `@oliveira-mauricio`_ for the PR.
 - The ``qt_api.extract_from_variant`` and ``qt_api.make_variant`` functions
-  (which were never intended for public usage) are now removed.
+  (which were never intended for public usage) as well as all class aliases
+  (such as ``qt_bot.QWidget`` or ``qt_bot.QEvent``, among others) are now
+  removed.
 - Errors related to the ``qt_compat`` module (such as an invalid
   ``PYTEST_QT_API`` setting or missing Qt API wrappers) are now shown as a more
   human-readable error message rather than an internal pytest error. Thanks

--- a/src/pytestqt/logging.py
+++ b/src/pytestqt/logging.py
@@ -133,7 +133,9 @@ class _QtMessageCapture:
         """
         Start receiving messages from Qt.
         """
-        previous_handler = qt_api.qInstallMessageHandler(self._handle_with_context)
+        previous_handler = qt_api.QtCore.qInstallMessageHandler(
+            self._handle_with_context
+        )
         self._previous_handler = previous_handler
 
     def _stop(self):
@@ -141,7 +143,7 @@ class _QtMessageCapture:
         Stop receiving messages from Qt, restoring the previously installed
         handler.
         """
-        qt_api.qInstallMessageHandler(self._previous_handler)
+        qt_api.QtCore.qInstallMessageHandler(self._previous_handler)
 
     @contextmanager
     def disabled(self):

--- a/src/pytestqt/modeltest.py
+++ b/src/pytestqt/modeltest.py
@@ -715,7 +715,7 @@ class ModelTester:
         Workaround for the fact that ``columnCount`` is a private method in
         QAbstractListModel/QAbstractTableModel subclasses.
         """
-        if isinstance(self._model, qt_api.QAbstractListModel):
+        if isinstance(self._model, qt_api.QtCore.QAbstractListModel):
             return 1 if parent == qt_api.QtCore.QModelIndex() else 0
         else:
             return self._model.columnCount(parent)
@@ -724,7 +724,10 @@ class ModelTester:
         """
         .. see:: ``_column_count``
         """
-        model_types = (qt_api.QAbstractListModel, qt_api.QAbstractTableModel)
+        model_types = (
+            qt_api.QtCore.QAbstractListModel,
+            qt_api.QtCore.QAbstractTableModel,
+        )
         if isinstance(self._model, model_types):
             return qt_api.QtCore.QModelIndex()
         else:
@@ -734,7 +737,10 @@ class ModelTester:
         """
         .. see:: ``_column_count``
         """
-        model_types = (qt_api.QAbstractListModel, qt_api.QAbstractTableModel)
+        model_types = (
+            qt_api.QtCore.QAbstractListModel,
+            qt_api.QtCore.QAbstractTableModel,
+        )
         if isinstance(self._model, model_types):
             return parent == qt_api.QtCore.QModelIndex() and self._model.rowCount() > 0
         else:

--- a/src/pytestqt/plugin.py
+++ b/src/pytestqt/plugin.py
@@ -51,10 +51,10 @@ def qapp(qapp_args, pytestconfig):
     You can use the ``qapp`` fixture in tests which require a ``QApplication``
     to run, but where you don't need full ``qtbot`` functionality.
     """
-    app = qt_api.QApplication.instance()
+    app = qt_api.QtWidgets.QApplication.instance()
     if app is None:
         global _qapp_instance
-        _qapp_instance = qt_api.QApplication(qapp_args)
+        _qapp_instance = qt_api.QtWidgets.QApplication(qapp_args)
         name = pytestconfig.getini("qt_qapp_name")
         _qapp_instance.setApplicationName(name)
         return _qapp_instance
@@ -197,7 +197,7 @@ def _process_events():
     """Calls app.processEvents() while taking care of capturing exceptions
     or not based on the given item's configuration.
     """
-    app = qt_api.QApplication.instance()
+    app = qt_api.QtWidgets.QApplication.instance()
     if app is not None:
         app.processEvents()
 

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -101,10 +101,9 @@ class _QtApi:
             return getattr(m, module_name)
 
         self.QtCore = QtCore = _import_module("QtCore")
-        self.QtGui = QtGui = _import_module("QtGui")
+        self.QtGui = _import_module("QtGui")
         self.QtTest = _import_module("QtTest")
-        self.Qt = QtCore.Qt
-        self.QEvent = QtCore.QEvent
+        self.QtWidgets = _import_module("QtWidgets")
 
         self._check_qt_api_version()
 
@@ -121,44 +120,14 @@ class _QtApi:
         self.qCritical = QtCore.qCritical
         self.qFatal = QtCore.qFatal
 
-        _QtWidgets = _import_module("QtWidgets")
-
         if self.is_pyside:
             self.Signal = QtCore.Signal
             self.Slot = QtCore.Slot
             self.Property = QtCore.Property
-            if hasattr(QtGui, "QStringListModel"):
-                self.QStringListModel = QtGui.QStringListModel
-            else:
-                self.QStringListModel = QtCore.QStringListModel
-
-            self.QStandardItem = QtGui.QStandardItem
-            self.QStandardItemModel = QtGui.QStandardItemModel
-            self.QAbstractListModel = QtCore.QAbstractListModel
-            self.QAbstractTableModel = QtCore.QAbstractTableModel
-
-            self.QApplication = _QtWidgets.QApplication
-            self.QWidget = _QtWidgets.QWidget
-            self.QLineEdit = _QtWidgets.QLineEdit
-            self.qInstallMessageHandler = QtCore.qInstallMessageHandler
-
-            self.QSortFilterProxyModel = QtCore.QSortFilterProxyModel
         elif self.is_pyqt:
             self.Signal = QtCore.pyqtSignal
             self.Slot = QtCore.pyqtSlot
             self.Property = QtCore.pyqtProperty
-
-            self.QApplication = _QtWidgets.QApplication
-            self.QWidget = _QtWidgets.QWidget
-            self.qInstallMessageHandler = QtCore.qInstallMessageHandler
-
-            self.QStringListModel = QtCore.QStringListModel
-            self.QSortFilterProxyModel = QtCore.QSortFilterProxyModel
-
-            self.QStandardItem = QtGui.QStandardItem
-            self.QStandardItemModel = QtGui.QStandardItemModel
-            self.QAbstractListModel = QtCore.QAbstractListModel
-            self.QAbstractTableModel = QtCore.QAbstractTableModel
         else:
             assert False, "Expected either is_pyqt or is_pyside"
 

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -165,7 +165,7 @@ class QtBot:
 
         .. note:: This method is also available as ``add_widget`` (pep-8 alias)
         """
-        if not isinstance(widget, qt_api.QWidget):
+        if not isinstance(widget, qt_api.QtWidgets.QWidget):
             raise TypeError("Need to pass a QWidget to addWidget!")
         _add_widget(self._request.node, widget, before_close_func=before_close_func)
 
@@ -265,7 +265,7 @@ class QtBot:
             if widget is not None:
                 widget_and_visibility.append((widget, widget.isVisible()))
 
-        qt_api.exec(qt_api.QApplication.instance())
+        qt_api.exec(qt_api.QtWidgets.QApplication.instance())
 
         for widget, visible in widget_and_visibility:
             widget.setVisible(visible)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -11,8 +11,8 @@ def test_basics(qtbot):
     Basic test that works more like a sanity check to ensure we are setting up a QApplication
     properly and are able to display a simple event_recorder.
     """
-    assert qt_api.QApplication.instance() is not None
-    widget = qt_api.QWidget()
+    assert qt_api.QtWidgets.QApplication.instance() is not None
+    widget = qt_api.QtWidgets.QWidget()
     qtbot.addWidget(widget)
     widget.setWindowTitle("W1")
     widget.show()
@@ -48,21 +48,25 @@ def test_key_events(qtbot, event_recorder):
     """
 
     def extract(key_event):
-        return (key_event.type(), qt_api.Qt.Key(key_event.key()), key_event.text())
+        return (
+            key_event.type(),
+            qt_api.QtCore.Qt.Key(key_event.key()),
+            key_event.text(),
+        )
 
     event_recorder.registerEvent(qt_api.QtGui.QKeyEvent, extract)
 
     qtbot.keyPress(event_recorder, "a")
     assert event_recorder.event_data == (
-        qt_api.QEvent.Type.KeyPress,
-        qt_api.Qt.Key.Key_A,
+        qt_api.QtCore.QEvent.Type.KeyPress,
+        qt_api.QtCore.Qt.Key.Key_A,
         "a",
     )
 
     qtbot.keyRelease(event_recorder, "a")
     assert event_recorder.event_data == (
-        qt_api.QEvent.Type.KeyRelease,
-        qt_api.Qt.Key.Key_A,
+        qt_api.QtCore.QEvent.Type.KeyRelease,
+        qt_api.QtCore.Qt.Key.Key_A,
         "a",
     )
 
@@ -79,7 +83,7 @@ def test_mouse_events(qtbot, event_recorder):
 
     qtbot.mousePress(event_recorder, qt_api.QtCore.Qt.MouseButton.LeftButton)
     assert event_recorder.event_data == (
-        qt_api.QEvent.Type.MouseButtonPress,
+        qt_api.QtCore.QEvent.Type.MouseButtonPress,
         qt_api.QtCore.Qt.MouseButton.LeftButton,
         qt_api.QtCore.Qt.KeyboardModifier.NoModifier,
     )
@@ -90,7 +94,7 @@ def test_mouse_events(qtbot, event_recorder):
         qt_api.QtCore.Qt.KeyboardModifier.AltModifier,
     )
     assert event_recorder.event_data == (
-        qt_api.QEvent.Type.MouseButtonPress,
+        qt_api.QtCore.QEvent.Type.MouseButtonPress,
         qt_api.QtCore.Qt.MouseButton.RightButton,
         qt_api.QtCore.Qt.KeyboardModifier.AltModifier,
     )
@@ -100,7 +104,7 @@ def test_stop_for_interaction(qtbot, timer):
     """
     Test qtbot.stopForInteraction()
     """
-    widget = qt_api.QWidget()
+    widget = qt_api.QtWidgets.QWidget()
     qtbot.addWidget(widget)
     qtbot.waitForWindowShown(widget)
     timer.single_shot_callback(widget.close, 0)
@@ -121,7 +125,7 @@ def test_wait_window(show, method_name, qtbot):
                 pass
         assert str(exc_info.value) == "Available in PyQt5 only"
     else:
-        widget = qt_api.QWidget()
+        widget = qt_api.QtWidgets.QWidget()
         qtbot.add_widget(widget)
         if show:
             with method(widget, timeout=1000):
@@ -142,7 +146,7 @@ def test_wait_window_propagates_other_exception(method_name, qtbot):
         pytest.skip("Available in PyQt5 only")
 
     method = getattr(qtbot, method_name)
-    widget = qt_api.QWidget()
+    widget = qt_api.QtWidgets.QWidget()
     qtbot.add_widget(widget)
     with pytest.raises(ValueError) as exc_info:
         with method(widget, timeout=100):
@@ -155,7 +159,7 @@ def test_widget_kept_as_weakref(qtbot):
     """
     Test if the widget is kept as a weak reference in QtBot
     """
-    widget = qt_api.QWidget()
+    widget = qt_api.QtWidgets.QWidget()
     qtbot.add_widget(widget)
     widget = weakref.ref(widget)
     assert widget() is None
@@ -186,10 +190,10 @@ def test_event_processing_before_and_after_teardown(testdir):
                     self.events = []
 
                 def pop_later(self):
-                    qapp.postEvent(self, qt_api.QEvent(qt_api.QEvent.Type.User))
+                    qapp.postEvent(self, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.Type.User))
 
                 def event(self, ev):
-                    if ev.type() == qt_api.QEvent.Type.User:
+                    if ev.type() == qt_api.QtCore.QEvent.Type.User:
                         self.events.pop(-1)
                     return qt_api.QtCore.QObject.event(self, ev)
 
@@ -275,7 +279,7 @@ def test_widgets_closed_before_fixtures(testdir):
         import pytest
         from pytestqt.qt_compat import qt_api
 
-        class Widget(qt_api.QWidget):
+        class Widget(qt_api.QtWidgets.QWidget):
 
             closed = False
 
@@ -307,7 +311,7 @@ def test_qtbot_wait(qtbot, stop_watch):
 
 @pytest.fixture
 def event_recorder(qtbot):
-    class EventRecorder(qt_api.QWidget):
+    class EventRecorder(qt_api.QtWidgets.QWidget):
 
         """
         Widget that records some kind of events sent to it.
@@ -318,7 +322,7 @@ def event_recorder(qtbot):
         """
 
         def __init__(self):
-            qt_api.QWidget.__init__(self)
+            qt_api.QtWidgets.QWidget.__init__(self)
             self._event_types = {}
             self.event_data = None
 
@@ -519,7 +523,7 @@ def test_before_close_func(testdir):
 
         @pytest.fixture
         def widget(qtbot):
-            w = qt_api.QWidget()
+            w = qt_api.QtWidgets.QWidget()
             w.some_id = 'my id'
             qtbot.add_widget(w, before_close_func=widget_closed)
             return w

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -31,7 +31,7 @@ def test_catch_exceptions_in_virtual_methods(testdir, raise_error):
 
         def test_exceptions(qtbot):
             v = Receiver()
-            app = qt_api.QApplication.instance()
+            app = qt_api.QtWidgets.QApplication.instance()
             app.sendEvent(v, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.Type.User))
             app.sendEvent(v, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.Type.User))
             app.processEvents()
@@ -106,13 +106,11 @@ def test_no_capture(testdir, no_capture_by_marker):
         import pytest
         import sys
         from pytestqt.qt_compat import qt_api
-        QWidget = qt_api.QWidget
-        QtCore = qt_api.QtCore
 
         # PyQt 5.5+ will crash if there's no custom exception handler installed
         sys.excepthook = lambda *args: None
 
-        class MyWidget(QWidget):
+        class MyWidget(qt_api.QtWidgets.QWidget):
 
             def mouseReleaseEvent(self, ev):
                 raise RuntimeError
@@ -141,8 +139,6 @@ def test_no_capture_preserves_custom_excepthook(testdir):
         import pytest
         import sys
         from pytestqt.qt_compat import qt_api
-        QWidget = qt_api.QWidget
-        QtCore = qt_api.QtCore
 
         def custom_excepthook(*args):
             sys.__excepthook__(*args)
@@ -171,18 +167,15 @@ def test_exception_capture_on_call(testdir):
         """
         import pytest
         from pytestqt.qt_compat import qt_api
-        QWidget = qt_api.QWidget
-        QtCore = qt_api.QtCore
-        QEvent = qt_api.QtCore.QEvent
 
-        class MyWidget(QWidget):
+        class MyWidget(qt_api.QtWidgets.QWidget):
 
             def event(self, ev):
                 raise RuntimeError('event processed')
 
         def test_widget(qtbot, qapp):
             w = MyWidget()
-            qapp.postEvent(w, QEvent(QEvent.Type.User))
+            qapp.postEvent(w, qt_api.QtCore.QEvent(QEvent.Type.User))
             qapp.processEvents()
     """
     )
@@ -200,11 +193,8 @@ def test_exception_capture_on_widget_close(testdir):
         """
         import pytest
         from pytestqt.qt_compat import qt_api
-        QWidget = qt_api.QWidget
-        QtCore = qt_api.QtCore
-        QEvent = qt_api.QtCore.QEvent
 
-        class MyWidget(QWidget):
+        class MyWidget(qt_api.QtWidgets.QWidget):
 
             def closeEvent(self, ev):
                 raise RuntimeError('close error')
@@ -238,15 +228,11 @@ def test_exception_capture_on_fixture_setup_and_teardown(testdir, mode):
         """
         import pytest
         from pytestqt.qt_compat import qt_api
-        QWidget = qt_api.QWidget
-        QtCore = qt_api.QtCore
-        QEvent = qt_api.QtCore.QEvent
-        QApplication = qt_api.QApplication
 
-        class MyWidget(QWidget):
+        class MyWidget(qt_api.QtWidgets.QWidget):
 
             def event(self, ev):
-                if ev.type() == QEvent.Type.User:
+                if ev.type() == qt_api.QtCore.QEvent.Type.User:
                     raise RuntimeError('event processed')
                 return True
 
@@ -258,7 +244,8 @@ def test_exception_capture_on_fixture_setup_and_teardown(testdir, mode):
             {teardown_code}
 
         def send_event(w, qapp):
-            qapp.postEvent(w, QEvent(QEvent.Type.User))
+            qapp.postEvent(w, qt_api.QtCore.QEvent(
+                qt_api.QtCore.QEvent.Type.User))
             qapp.processEvents()
 
         def test_capture(widget):
@@ -307,12 +294,10 @@ def test_capture_exceptions_qtbot_context_manager(testdir):
         """
         import pytest
         from pytestqt.qt_compat import qt_api
-        QWidget = qt_api.QWidget
-        Signal = qt_api.Signal
 
-        class MyWidget(QWidget):
+        class MyWidget(qt_api.QtWidgets.QWidget):
 
-            on_event = Signal()
+            on_event = qt_api.Signal()
 
         def test_widget(qtbot):
             widget = MyWidget()
@@ -341,14 +326,14 @@ def test_exceptions_to_stderr(qapp, capsys):
     called = []
     from pytestqt.qt_compat import qt_api
 
-    class MyWidget(qt_api.QWidget):
+    class MyWidget(qt_api.QtWidgets.QWidget):
         def event(self, ev):
             called.append(1)
             raise RuntimeError("event processed")
 
     w = MyWidget()
     with capture_exceptions() as exceptions:
-        qapp.postEvent(w, qt_api.QEvent(qt_api.QEvent.Type.User))
+        qapp.postEvent(w, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.Type.User))
         qapp.processEvents()
     assert called
     del exceptions[:]
@@ -370,7 +355,7 @@ def test_exceptions_dont_leak(testdir):
         import gc
         import weakref
 
-        class MyWidget(qt_api.QWidget):
+        class MyWidget(qt_api.QtWidgets.QWidget):
 
             def event(self, ev):
                 called.append(1)
@@ -383,7 +368,7 @@ def test_exceptions_dont_leak(testdir):
             global weak_ref
             w = MyWidget()
             weak_ref = weakref.ref(w)
-            qapp.postEvent(w, qt_api.QEvent(qt_api.QEvent.Type.User))
+            qapp.postEvent(w, qt_api.QtCore.QEvent(qt_api.QtCore.QEvent.Type.User))
             qapp.processEvents()
 
         def test_2(qapp):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -23,7 +23,7 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
 
         def print_msg(msg_type, context, message):
             sys.stderr.write(to_unicode(message) + '\\n')
-        qt_api.qInstallMessageHandler(print_msg)
+        qt_api.QtCore.qInstallMessageHandler(print_msg)
 
         def test_types():
             # qInfo is not exposed by the bindings yet (#225)

--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -25,10 +25,10 @@ class BasicModel(qt_api.QtCore.QAbstractItemModel):
 
 def test_standard_item_model(qtmodeltester):
     """
-    Basic test which uses qtmodeltester with a qt_api.QStandardItemModel.
+    Basic test which uses qtmodeltester with a qt_api.QtGui.QStandardItemModel.
     """
-    model = qt_api.QStandardItemModel()
-    items = [qt_api.QStandardItem(str(i)) for i in range(6)]
+    model = qt_api.QtGui.QStandardItemModel()
+    items = [qt_api.QtGui.QStandardItem(str(i)) for i in range(6)]
     model.setItem(0, 0, items[0])
     model.setItem(0, 1, items[1])
     model.setItem(1, 0, items[2])
@@ -41,15 +41,15 @@ def test_standard_item_model(qtmodeltester):
 
 
 def test_string_list_model(qtmodeltester):
-    model = qt_api.QStringListModel()
+    model = qt_api.QtCore.QStringListModel()
     model.setStringList(["hello", "world"])
     qtmodeltester.check(model, force_py=True)
 
 
 def test_sort_filter_proxy_model(qtmodeltester):
-    model = qt_api.QStringListModel()
+    model = qt_api.QtCore.QStringListModel()
     model.setStringList(["hello", "world"])
-    proxy = qt_api.QSortFilterProxyModel()
+    proxy = qt_api.QtCore.QSortFilterProxyModel()
     proxy.setSourceModel(model)
     qtmodeltester.check(proxy, force_py=True)
 
@@ -74,7 +74,7 @@ def test_broken_types(check_model, broken_role):
     values for various display roles.
     """
 
-    class BrokenTypeModel(qt_api.QAbstractListModel):
+    class BrokenTypeModel(qt_api.QtCore.QAbstractListModel):
         def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
             if parent == qt_api.QtCore.QModelIndex():
                 return 1
@@ -109,7 +109,7 @@ def test_data_alignment(role_value, should_pass, check_model):
     qtmodeltest should capture this problem and fail when that happens.
     """
 
-    class MyModel(qt_api.QAbstractListModel):
+    class MyModel(qt_api.QtCore.QAbstractListModel):
         def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
             return 1 if parent == qt_api.QtCore.QModelIndex() else 0
 
@@ -129,7 +129,7 @@ def test_data_alignment(role_value, should_pass, check_model):
 
 
 def test_header_handling(check_model):
-    class MyModel(qt_api.QAbstractListModel):
+    class MyModel(qt_api.QtCore.QAbstractListModel):
         def rowCount(self, parent=qt_api.QtCore.QModelIndex()):
             return 1 if parent == qt_api.QtCore.QModelIndex() else 0
 
@@ -193,23 +193,23 @@ def test_invalid_column_count(qtmodeltester):
 
 
 def test_changing_model_insert(qtmodeltester):
-    model = qt_api.QStandardItemModel()
-    item = qt_api.QStandardItem("foo")
+    model = qt_api.QtGui.QStandardItemModel()
+    item = qt_api.QtGui.QStandardItem("foo")
     qtmodeltester.check(model, force_py=True)
     model.insertRow(0, item)
 
 
 def test_changing_model_remove(qtmodeltester):
-    model = qt_api.QStandardItemModel()
-    item = qt_api.QStandardItem("foo")
+    model = qt_api.QtGui.QStandardItemModel()
+    item = qt_api.QtGui.QStandardItem("foo")
     model.setItem(0, 0, item)
     qtmodeltester.check(model, force_py=True)
     model.removeRow(0)
 
 
 def test_changing_model_data(qtmodeltester):
-    model = qt_api.QStandardItemModel()
-    item = qt_api.QStandardItem("foo")
+    model = qt_api.QtGui.QStandardItemModel()
+    item = qt_api.QtGui.QStandardItem("foo")
     model.setItem(0, 0, item)
     qtmodeltester.check(model, force_py=True)
     model.setData(model.index(0, 0), "hello world")
@@ -220,8 +220,8 @@ def test_changing_model_data(qtmodeltester):
     [qt_api.QtCore.Qt.Orientation.Horizontal, qt_api.QtCore.Qt.Orientation.Vertical],
 )
 def test_changing_model_header_data(qtmodeltester, orientation):
-    model = qt_api.QStandardItemModel()
-    item = qt_api.QStandardItem("foo")
+    model = qt_api.QtGui.QStandardItemModel()
+    item = qt_api.QtGui.QStandardItem("foo")
     model.setItem(0, 0, item)
     qtmodeltester.check(model, force_py=True)
     model.setHeaderData(0, orientation, "blah")
@@ -229,8 +229,8 @@ def test_changing_model_header_data(qtmodeltester, orientation):
 
 def test_changing_model_sort(qtmodeltester):
     """Sorting emits layoutChanged"""
-    model = qt_api.QStandardItemModel()
-    item = qt_api.QStandardItem("foo")
+    model = qt_api.QtGui.QStandardItemModel()
+    item = qt_api.QtGui.QStandardItem("foo")
     model.setItem(0, 0, item)
     qtmodeltester.check(model, force_py=True)
     model.sort(0)
@@ -264,7 +264,7 @@ def test_overridden_methods(qtmodeltester):
 
 
 def test_fetch_more(qtmodeltester):
-    class Model(qt_api.QStandardItemModel):
+    class Model(qt_api.QtGui.QStandardItemModel):
         def canFetchMore(self, parent):
             return True
 
@@ -273,13 +273,13 @@ def test_fetch_more(qtmodeltester):
             self.setData(self.index(0, 0), "bar")
 
     model = Model()
-    item = qt_api.QStandardItem("foo")
+    item = qt_api.QtGui.QStandardItem("foo")
     model.setItem(0, 0, item)
     qtmodeltester.check(model, force_py=True)
 
 
 def test_invalid_parent(qtmodeltester):
-    class Model(qt_api.QStandardItemModel):
+    class Model(qt_api.QtGui.QStandardItemModel):
         def parent(self, index):
             if index == self.index(0, 0, parent=self.index(0, 0)):
                 return self.index(0, 0)
@@ -287,9 +287,9 @@ def test_invalid_parent(qtmodeltester):
                 return qt_api.QtCore.QModelIndex()
 
     model = Model()
-    item = qt_api.QStandardItem("foo")
-    item2 = qt_api.QStandardItem("bar")
-    item3 = qt_api.QStandardItem("bar")
+    item = qt_api.QtGui.QStandardItem("foo")
+    item2 = qt_api.QtGui.QStandardItem("bar")
+    item3 = qt_api.QtGui.QStandardItem("bar")
     model.setItem(0, 0, item)
     item.setChild(0, item2)
     item2.setChild(0, item3)
@@ -309,7 +309,7 @@ def test_qt_tester_valid(testdir):
 
 
         def test_ok(qtmodeltester):
-            model = qt_api.QStandardItemModel()
+            model = qt_api.QtGui.QStandardItemModel()
             qtmodeltester.check(model)
         """
     )

--- a/tests/test_qtest_proxies.py
+++ b/tests/test_qtest_proxies.py
@@ -42,10 +42,10 @@ def test_keyToAscii_not_available_on_pyqt(testdir):
         from pytestqt.qt_compat import qt_api
 
         def test_foo(qtbot):
-            widget = qt_api.QWidget()
+            widget = qt_api.QtWidgets.QWidget()
             qtbot.add_widget(widget)
             with pytest.raises(NotImplementedError):
-                qtbot.keyToAscii(qt_api.Qt.Key.Key_Escape)
+                qtbot.keyToAscii(qt_api.QtCore.Qt.Key.Key_Escape)
         """
     )
     result = testdir.runpytest()


### PR DESCRIPTION
Removes all aliases to class names, since those were only needed back when those
classes were in different modules between Qt 4 and Qt 5 (typically QtGui vs.
QtWidgets).

With Qt 4 now dropped, Qt 5 and Qt 6 are compatible enough to use the full path
to the classes inside our code instead, which makes the wrapper much simpler.

This also cleans up some tests doing "QtCore = qt_api.QtCore" or similar, since
there were a lot of duplicated but unused such aliases. Seems simpler to me to
just use the direct name, even if a bit longer.

Fixes #354