### PR TITLE
Improve logging context handling

### DIFF
--- a/src/pytestqt/logging.py
+++ b/src/pytestqt/logging.py
@@ -83,12 +83,9 @@ class QtLoggingPlugin:
                     log_format = self.config.getoption("qt_log_format")
                     context_format = None
                     if log_format is None:
-                        if qt_api.pytest_qt_api == "pyqt5":
-                            context_format = "{rec.context.file}:{rec.context.function}:{rec.context.line}:\n"
-                            log_format = "    {rec.type_name}: {rec.message}"
-                        else:
-                            context_format = None
-                            log_format = "{rec.type_name}: {rec.message}"
+                        context_format = "{rec.context.file}:{rec.context.function}:{rec.context.line}:\n"
+                        log_format = "    {rec.type_name}: {rec.message}"
+
                     lines = []
                     for rec in item.qt_log_capture.records:
                         suffix = " (IGNORED)" if rec.ignored else ""
@@ -104,6 +101,8 @@ class QtLoggingPlugin:
                         ):
                             context_line = context_format.format(rec=rec)
                             lines.append(context_line)
+                        else:
+                            log_format = log_format.lstrip()
 
                         line = log_format.format(rec=rec) + suffix
                         lines.append(line)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -485,7 +485,7 @@ def test_lineno_failure(testdir):
         """
     )
     res = testdir.runpytest()
-    if qt_api.pytest_qt_api == "pyqt5":
+    if qt_api.is_pyqt:
         res.stdout.fnmatch_lines(
             [
                 "*test_lineno_failure.py:2: Failure*",
@@ -494,12 +494,17 @@ def test_lineno_failure(testdir):
             ]
         )
     else:
-        res.stdout.fnmatch_lines("*test_lineno_failure.py:2: Failure*")
+        res.stdout.fnmatch_lines(
+            [
+                "*test_lineno_failure.py:2: Failure*",
+                "QtWarningMsg: this is a WARNING message",
+            ]
+        )
 
 
 def test_context_none(testdir):
     """
-    Sometimes PyQt5 will emit a context with some/all attributes set as None
+    Sometimes PyQt will emit a context with some/all attributes set as None
     instead of appropriate file, function and line number.
 
     Test that when this happens the plugin doesn't break, and it filters
@@ -507,8 +512,6 @@ def test_context_none(testdir):
 
     :type testdir: _pytest.pytester.TmpTestdir
     """
-    if qt_api.pytest_qt_api != "pyqt5":
-        pytest.skip("Context information only available in PyQt5")
     testdir.makepyfile(
         """
         from pytestqt.qt_compat import qt_api
@@ -523,7 +526,7 @@ def test_context_none(testdir):
     )
     res = testdir.runpytest()
     assert "*None:None:0:*" not in str(res.stdout)
-    res.stdout.fnmatch_lines(["* QtWarningMsg: WARNING message*"])
+    res.stdout.fnmatch_lines(["QtWarningMsg: WARNING message"])
 
 
 def test_logging_broken_makereport(testdir):


### PR DESCRIPTION
Logging context is available with PyQt6. However, given we dropped Qt 4 and the
old qInstallMsgHandler (without a context argument at all), we can now simplify
the code: If a context is available, we use it without any Qt API checks; if
none is available, we don't (and remove the indent from the log message
pattern).

Fixes #364