### PR TITLE
Avoid using .isdeleted/.isValid in tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+4.0.2 (UNRELEASED)
+------------------
+
+- Restored compatibility with PySide2 5.11, which doesn't depend on the
+  ``shiboken2`` project, used by pytest-qt 4.0.0. The dependency is now not
+  needed anymore, and the ``.isdeleted`` attribute of ``qt_compat`` (which
+  isn't intended for public use) is removed.
+
 4.0.1 (2021-06-07)
 ------------------
 

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -131,23 +131,6 @@ class _QtApi:
         else:
             assert False, "Expected either is_pyqt or is_pyside"
 
-        if self.pytest_qt_api == "pyside2":
-            import shiboken2
-
-            self.isdeleted = lambda obj: not shiboken2.isValid(obj)
-        elif self.pytest_qt_api == "pyside6":
-            import shiboken6
-
-            self.isdeleted = lambda obj: not shiboken6.isValid(obj)
-        else:
-            assert self.is_pyqt
-            try:
-                sip = _import_module("sip")
-            except AttributeError:
-                # some distributions still package PyQt5.sip as sip (#396)
-                import sip
-            self.isdeleted = sip.isdeleted
-
     def _check_qt_api_version(self):
         if not self.is_pyqt:
             # We support all PySide versions

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -382,7 +382,8 @@ def test_destroyed(qtbot):
     with qtbot.waitSignal(obj.destroyed):
         obj.deleteLater()
 
-    assert qt_api.isdeleted(obj)
+    with pytest.raises(RuntimeError):
+        obj.objectName()
 
 
 class TestArgs:


### PR DESCRIPTION
This has caused us a lot of trouble since the 4.0.0 release
(see #369 and #373). However, it was only neeeded for tests, where we
might as well just check if the object is alive by calling a Qt method
and checking for the exception (RuntimeError with all Qt APIs).

Fixes #373