### PR TITLE
Simplify PEP8 method aliases in QtBot class.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+UNRELEASED
+----------
+
+- Improved PEP-8 aliases definition so they have a smaller call stack depth by one and better parameter suggestions in IDEs. (`#383`_). Thanks `@luziferius`_ for the PR.
+
+.. _#383: https://github.com/pytest-dev/pytest-qt/pull/383
+.. _@luziferius: https://github.com/luziferius
+
 4.0.2 (2021-06-14)
 ------------------
 

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -138,6 +138,17 @@ class QtBot:
 
     def __init__(self, request):
         self._request = request
+        # pep8 aliases. Set here to automatically use implementations defined in sub-classes for alias creation
+        self.add_widget = self.addWidget
+        self.capture_exceptions = self.captureExceptions
+        self.wait_active = self.waitActive
+        self.wait_exposed = self.waitExposed
+        self.wait_for_window_shown = self.waitForWindowShown
+        self.wait_signal = self.waitSignal
+        self.wait_signals = self.waitSignals
+        self.assert_not_emitted = self.assertNotEmitted
+        self.wait_until = self.waitUntil
+        self.wait_callback = self.waitCallback
 
     def _should_raise(self, raising_arg):
         ini_val = self._request.config.getini("qt_default_raising")
@@ -644,35 +655,6 @@ class QtBot:
     @staticmethod
     def mouseRelease(*args, **kwargs):
         qt_api.QtTest.QTest.mouseRelease(*args, **kwargs)
-
-    # pep-8 aliases
-
-    def add_widget(self, *args, **kwargs):
-        return self.addWidget(*args, **kwargs)
-
-    def wait_active(self, *args, **kwargs):
-        return self.waitActive(*args, **kwargs)
-
-    def wait_exposed(self, *args, **kwargs):
-        return self.waitExposed(*args, **kwargs)
-
-    def wait_for_window_shown(self, *args, **kwargs):
-        return self.waitForWindowShown(*args, **kwargs)
-
-    def wait_signal(self, *args, **kwargs):
-        return self.waitSignal(*args, **kwargs)
-
-    def wait_signals(self, *args, **kwargs):
-        return self.waitSignals(*args, **kwargs)
-
-    def assert_not_emitted(self, *args, **kwargs):
-        return self.assertNotEmitted(*args, **kwargs)
-
-    def wait_until(self, *args, **kwargs):
-        return self.waitUntil(*args, **kwargs)
-
-    def wait_callback(self, *args, **kwargs):
-        return self.waitCallback(*args, **kwargs)
 
 
 # provide easy access to exceptions to qtbot fixtures

--- a/tests/test_qtbot_pep8_aliases.py
+++ b/tests/test_qtbot_pep8_aliases.py
@@ -1,0 +1,92 @@
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from pytestqt.qtbot import QtBot
+
+
+def _format_pep_8(camel_case_name: str) -> str:
+    """
+    Helper that creates a pep8_compliant_method_name
+    from a given camelCaseMethodName.
+    """
+    return camel_case_name[0].lower() + "".join(
+        f"_{letter.lower()}" if letter.isupper() else letter.lower()
+        for letter in camel_case_name[1:]
+    )
+
+
+@pytest.mark.parametrize(
+    "expected, camel_case_input",
+    [
+        ("add_widget", "addWidget"),
+        ("wait_active", "waitActive"),
+        ("wait_exposed", "waitExposed"),
+        ("wait_for_window_shown", "waitForWindowShown"),
+        ("wait_signal", "waitSignal"),
+        ("wait_signals", "waitSignals"),
+        ("assert_not_emitted", "assertNotEmitted"),
+        ("wait_until", "waitUntil"),
+        ("wait_callback", "waitCallback"),
+    ],
+)
+def test_format_pep8(expected: str, camel_case_input: str):
+    assert _format_pep_8(camel_case_input) == expected
+
+
+def test_pep8_aliases(qtbot):
+    """
+    Test that defined PEP8 aliases actually refer to the correct implementation.
+    Only check methods that have such an alias defined.
+    """
+    for name, func in inspect.getmembers(qtbot, inspect.ismethod):
+        if name != name.lower():
+            pep8_name = _format_pep_8(name)
+            if hasattr(qtbot, pep8_name):
+                # Found a PEP8 alias.
+                assert (
+                    getattr(qtbot, name).__func__ is getattr(qtbot, pep8_name).__func__
+                )
+
+
+def generate_test_cases_for_test_subclass_of_qtbot_has_overwritten_pep8_aliases():
+    """
+    For each PEP8 alias found in QtBot, yields a test case consisting of
+    a QtBot subclass that has the alias pair’s camelCase implementation
+    overwritten with a MagicMock.
+
+    Yields tuples (subclass, camelCaseMethodName, pep8_method_name_alias)
+    """
+    for name, func in inspect.getmembers(QtBot, inspect.isfunction):
+        if name != name.lower():
+            subclass_logic_mock = MagicMock()
+            pep8_name = _format_pep_8(name)
+            if hasattr(QtBot, pep8_name):
+                # Found a PEP8 alias.
+                methods = QtBot.__dict__.copy()
+                # Only overwrite the camelCase method
+                methods[name] = subclass_logic_mock
+                sub_class = type("QtBotSubclass", (QtBot,), methods)
+                yield sub_class, name, pep8_name
+
+
+@pytest.mark.parametrize(
+    "qtbot_subclass, method_name, pep8_name",
+    generate_test_cases_for_test_subclass_of_qtbot_has_overwritten_pep8_aliases(),
+)
+def test_subclass_of_qtbot_has_overwritten_pep8_aliases(
+    qtbot_subclass, method_name: str, pep8_name: str
+):
+    """
+    Test that subclassing QtBot does not create surprises,
+    by checking that the PEP8 aliases follow overwritten
+    camelCase methods.
+    """
+    instance: QtBot = qtbot_subclass(MagicMock())
+    assert isinstance(getattr(instance, method_name), MagicMock)
+    assert isinstance(getattr(instance, pep8_name), MagicMock)
+    # Now call the pep8_name_method and check that the subclass’s
+    # camelCaseMethod implementation was actually called.
+    getattr(instance, pep8_name)()
+    getattr(instance, method_name).assert_called()


### PR DESCRIPTION
This commit simplifies the creation of PEP8 compliant method aliases.

It reduces call stack depth by one and enables better parameter suggestions in IDEs.

Before:
![qtbot_args](https://user-images.githubusercontent.com/2143820/128164847-c8569640-1f24-4ab9-aba7-7a6e8b6ebacf.png)

After:
![qtbot_args_new](https://user-images.githubusercontent.com/2143820/128164909-4b48b155-e497-4f01-900a-ffc537d06341.png)


Also added unit test verifying that each alias points to the correct source method.

(I hope that the test function location is OK)