### PR TITLE
Add new qapp_cls fixture

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ UNRELEASED
 - ``pytest-qt`` now requires Python 3.7+.
 - Improved PEP-8 aliases definition so they have a smaller call stack depth by one and better parameter suggestions in IDEs. (`#383`_). Thanks `@luziferius`_ for the PR.
 - Updated model tester handling around ``hasChildren`` based on Qt's updates.
+- New ``qapp_cls`` fixture returning the ``QApplication`` class to use, thus
+  making it easier to use a custom subclass without having to override the
+  whole ``qapp`` fixture. Thanks `@The-Compiler`_ for the PR.
 
 .. _#383: https://github.com/pytest-dev/pytest-qt/pull/383
 .. _@luziferius: https://github.com/luziferius

--- a/docs/qapplication.rst
+++ b/docs/qapplication.rst
@@ -64,13 +64,16 @@ custom application like below:
 
 If your tests require access to app-level functions, like
 ``CustomQApplication.custom_function()``, you can override the built-in
-``qapp`` fixture in your ``conftest.py`` to use your own app:
+``qapp_cls`` fixture in your ``conftest.py`` to return your custom class:
 
 .. code-block:: python
 
     @pytest.fixture(scope="session")
-    def qapp():
-        yield CustomQApplication([])
+    def qapp_cls():
+        return CustomQApplication
+
+The ``qapp`` fixture will then use the returned class instead of the default
+``QApplication`` from ``QtWidgets``.
 
 Setting a QApplication name
 ---------------------------


### PR DESCRIPTION
This allows to override the QApplication class to use without breaking existing functionality of the qapp fixture.

Currently, if someone follows the doc, things like `qapp_args` or the `qt_qapp_name` setting break.

Also add a few more tests around `qapp` handling and reuse.