### PR TITLE
Update model tester handling around hasChildren()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 - Improved PEP-8 aliases definition so they have a smaller call stack depth by one and better parameter suggestions in IDEs. (`#383`_). Thanks `@luziferius`_ for the PR.
+- Updated model tester handling around ``hasChildren`` based on Qt's updates.
 
 .. _#383: https://github.com/pytest-dev/pytest-qt/pull/383
 .. _@luziferius: https://github.com/luziferius

--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -54,6 +54,23 @@ def test_sort_filter_proxy_model(qtmodeltester):
     qtmodeltester.check(proxy, force_py=True)
 
 
+def test_standard_item_model_zero_columns(qtmodeltester):
+    model = qt_api.QtGui.QStandardItemModel()
+    qtmodeltester.check(model, force_py=True)
+
+    # QTBUG-92220
+    model.insertRows(0, 5)
+    model.removeRows(0, 5)
+
+    # QTBUG-92886
+    model.insertRows(0, 5)
+    model.removeRows(1, 2)
+
+    parent_index = model.index(0, 0)
+    model.insertRows(0, 5, parent_index)
+    model.insertRows(1, 2, parent_index)
+
+
 @pytest.mark.parametrize(
     "broken_role",
     [


### PR DESCRIPTION
Relevant upstream changes:

QAbstractItemModelTester: don't rely on hasChildren()
https://codereview.qt-project.org/c/qt/qtbase/+/318767

    Dynamic models which use fetchMore to asynchronously fill subdirs
    (like KDirModel) return true in hasChildren() for dirs that are expected
    to have children (so that the "+" shows in the treeview) but do not
    actually have children readily available.
    They will be inserted later on once the async listing job is done
    (as a result of fetchMore triggering that job).

    So QAbstractItemModelTester should use rowCount instead, to find out
    if there are children present.

    This detected a bug in QConcatenateTablesProxyModel: it returned
    a non-zero rowCount for its items, while it's flat.

QAbstractItemModelTester: fix false positive when model has zero columns
https://codereview.qt-project.org/c/qt/qtbase/+/341238
https://bugreports.qt.io/browse/QTBUG-92220

Fix QAbstractItemModelTester false positive
https://codereview.qt-project.org/c/qt/qtbase/+/343539
https://bugreports.qt.io/browse/QTBUG-92886

    When rows are removed from a model with no columns,
    the test should not report a problem if indexes are invalid

Fix QAbstractItemModelTester false positive
https://codereview.qt-project.org/c/qt/qtbase/+/345195

    When inserting rows to a branch with no columns
    the tester should not complain about indexes being invalid

---

Still missing one bigger change which I plan to do separately:

[Add tests to QAbstractItemModelTester checking only one change in flight (I15fe1ad1) · Gerrit Code Review](https://codereview.qt-project.org/c/qt/qtbase/+/396208)