### PR TITLE
Track in-flight changes in model tester

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED
 - New ``qapp_cls`` fixture returning the ``QApplication`` class to use, thus
   making it easier to use a custom subclass without having to override the
   whole ``qapp`` fixture. Thanks `@The-Compiler`_ for the PR.
+- Updated model tester to track/verify in-flight changes based on Qt's updates.
 
 .. _#383: https://github.com/pytest-dev/pytest-qt/pull/383
 .. _@luziferius: https://github.com/luziferius


### PR DESCRIPTION
Relevant upstream change:

Add tests to QAbstractItemModelTester checking only one change in flight
https://codereview.qt-project.org/c/qt/qtbase/+/396208

---

A bit light on tests unfortunately (read: none added despite lots of new functionality), but so is the upstream change, unfortunately...