### PR TITLE
Update pycharm logo URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,8 +178,9 @@ Many thanks to:
 
 **Powered by**
 
-.. |pycharm| image:: https://www.jetbrains.com/pycharm/docs/logo_pycharm.png
+.. |pycharm| image:: https://resources.jetbrains.com/storage/products/company/brand/logos/PyCharm.png
   :target: https://www.jetbrains.com/pycharm
+  :width: 400
 
 .. |pydev| image:: http://www.pydev.org/images/pydev_banner3.png
   :target: https://www.pydev.org


### PR DESCRIPTION
The old URL seems to redirect to a .zip file nowadays... New URL from here: https://www.jetbrains.com/company/brand/

Preview: https://github.com/The-Compiler/pytest-qt/blob/0cfefd77fb0f8274f14b18046d9087e5b7f18de4/README.rst#contributing