### PR TITLE
fix tiny docstring typo

### DIFF
--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -241,7 +241,7 @@ class QtBot:
             This method does **not** raise ``TimeoutError`` if the window wasn't shown.
 
         .. deprecated:: 4.0
-            Use the qtbot.waitForWindowExposed context manager instead.
+            Use the ``qtbot.waitExposed`` context manager instead.
 
         :param QWidget widget:
             Widget to wait on.


### PR DESCRIPTION
Heya,

not that this is super important or anything, and the warning also hints at the right method, but correct documentation is also not bad.

Cheers
D