### PR TITLE
CI workflow improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Build package
       run: |
@@ -30,7 +30,7 @@ jobs:
         python -m build
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.5.0
+      uses: pypa/gh-action-pypi-publish@v1.5.1
       with:
         user: __token__
         password: ${{ secrets.pypi_token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: deploy
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+
+  deploy:
+    if: github.repository == 'pytest-dev/pytest-qt'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+
+    - name: Build package
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+        python -m build
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.5.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,34 +59,13 @@ jobs:
       run: |
         tox -e ${{ matrix.tox-env }}-${{ matrix.qt-lib }} -- -ra --color=yes
 
-  checks:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.7"
-    - name: Install tox
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-    - name: Linting
-      run: |
-        tox -e linting
-    - name: Docs
-      run: |
-        tox -e docs
-
   deploy:
 
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
     runs-on: ubuntu-latest
 
-    needs: [build, checks]
+    needs: build
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         qt-lib: [pyqt5, pyqt6, pyside2, pyside6]
         os: [ubuntu-20.04, windows-latest, macos-latest]
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,29 +58,3 @@ jobs:
     - name: Test with tox
       run: |
         tox -e ${{ matrix.tox-env }}-${{ matrix.qt-lib }} -- -ra --color=yes
-
-  deploy:
-
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-
-    runs-on: ubuntu-latest
-
-    needs: build
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.7"
-    - name: Build package
-      run: |
-        python -m pip install --upgrade pip setuptools
-        pip install wheel
-        python setup.py sdist bdist_wheel
-    - name: Publish package to PyPI
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.5.0
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             tox-env: "py39"
           - python-version: "3.10"
             tox-env: "py310"
-          - python-version: "3.11-dev"
+          - python-version: "3.11"
             tox-env: "py311"
         # https://bugreports.qt.io/browse/PYSIDE-1797
         exclude:
@@ -34,10 +34,10 @@ jobs:
             python-version: "3.7"
           # Not installable so far
           - qt-lib: pyside6
-            python-version: "3.11-dev"
+            python-version: "3.11"
           - qt-lib: pyside2
             os: windows-latest
-            python-version: "3.11-dev"
+            python-version: "3.11"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
* Drop 'checks' job from CI: this job is redundant now that we use pre-commit.ci and readthedocs builds docs for PRs.
* Split workflows into 'deploy' and 'build' for easier management.