### PR TITLE
Stop importing from py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,12 @@
 UNRELEASED
 ----------
 
+- Import the ``code`` sub-package from the correct location rather than the
+  deprecated ``py`` package, restoring compatibility with pytest 7.2.0, where
+  ``py`` was dropped. Thanks `@The-Compiler`_ for the PR.
+
 - Use ``pytest.hookimpl`` to configure hooks, avoiding a deprecation warning in
-  the upcoming pytest 7.2.0.
+  pytest 7.2.0. Thanks `@The-Compiler`_ for the PR.
 
 - Now ``pytest-qt`` will check if any of the Qt libraries is already imported by the time the plugin loads,
   and use it if that is the case (`#412`_). Thanks `@eyllanesc`_ for the PR.

--- a/src/pytestqt/logging.py
+++ b/src/pytestqt/logging.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 import datetime
 import re
-from py._code.code import TerminalRepr, ReprFileLocation
+from _pytest._code.code import TerminalRepr, ReprFileLocation
 import pytest
 from pytestqt.qt_compat import qt_api
 from pytestqt.utils import get_marker


### PR DESCRIPTION
py._code has been moved to _pytest._code with pytest 2.9.0: https://docs.pytest.org/en/latest/changelog.html#id395

We still imported from py._code without actually depending from py. While this happened to work, it now breaks due to pytest dropping py: https://github.com/pytest-dev/pytest/pull/10396

Resulting in:

    File ".../src/pytestqt/logging.py", line 5, in <module>
        from py._code.code import TerminalRepr, ReprFileLocation
    ModuleNotFoundError: No module named 'py._code'; 'py' is not a package

with the latest pytest main.