### PR TITLE
Support an existing asyncio loop such as qasync

### DIFF
--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -473,6 +473,28 @@ class QtBot:
             yield
         spy.assert_not_emitted()
 
+    @contextlib.asynccontextmanager
+    async def a_assertNotEmitted(self, signal, *, wait=0):
+        """
+        .. versionadded:: 1.11
+
+        Make sure the given ``signal`` doesn't get emitted.
+
+        :param int wait:
+            How many milliseconds to wait to make sure the signal isn't emitted
+            asynchronously. By default, this method returns immediately and only
+            catches signals emitted inside the ``with``-block.
+
+        This is intended to be used as a context manager.
+
+        .. note:: This method is also available as ``assert_not_emitted``
+                  (pep-8 alias)
+        """
+        spy = SignalEmittedSpy(signal)
+        async with spy, self.waitSignal(signal, timeout=wait, raising=False):
+            yield
+        spy.assert_not_emitted()
+
     def waitUntil(self, callback, *, timeout=5000):
         """
         .. versionadded:: 2.0

--- a/src/pytestqt/wait_signal.py
+++ b/src/pytestqt/wait_signal.py
@@ -191,6 +191,8 @@ class _AbstractSignalBlocker:
         return signal_tuple
 
     def __enter__(self):
+        if self._loop._async:
+            raise RuntimeError("use 'async with qtbot...' in an async context")
         return self
 
     def __exit__(self, type, value, traceback):
@@ -200,6 +202,7 @@ class _AbstractSignalBlocker:
             self.wait()
 
     async def __aenter__(self):
+        assert self._loop._async, "qtbot can only be awaited in an async context"
         return self
 
     async def __aexit__(self, type, value, traceback):
@@ -788,6 +791,8 @@ class CallbackBlocker:
             self._loop.quit()
 
     def __enter__(self):
+        if self._loop._async:
+            raise RuntimeError("use 'async with qtbot...' in an async context")
         return self
 
     def __exit__(self, type, value, traceback):
@@ -797,6 +802,7 @@ class CallbackBlocker:
             self.wait()
 
     async def __aenter__(self):
+        assert self._loop._async, "qtbot can only be awaited in an async context"
         return self
 
     async def __aexit__(self, type, value, traceback):

--- a/src/pytestqt/wait_signal.py
+++ b/src/pytestqt/wait_signal.py
@@ -663,6 +663,12 @@ class SignalEmittedSpy:
     def __exit__(self, type, value, traceback):
         self.signal.disconnect(self.slot)
 
+    async def __aenter__(self):
+        self.__enter__()
+
+    async def __aexit__(self, type, value, traceback):
+        self.__exit__(type, value, traceback)
+
     def assert_not_emitted(self):
         if self.emitted:
             if self.args:


### PR DESCRIPTION
When running tests in an async development environment there may already be a running loop which is assumed to be Qt compatible.

This approach allows the loop to be detected and used rather than creating a new one.

This test uses async Django calls and qasync

```
async def test_mqtest_save_db(qtbot, sensors, mqtest, db_record):
    async with qtbot.waitSignal(mqtest.signal_db_saved) as waiter:
        mqtest.db.tests = "New Value"
        mqtest.signal_save_db.emit()
    rec = await ATestRecord.objects.aget(pk=db_record.id)
    assert rec.tests == "New Value"
 ```