### PR TITLE
Docs: suggest direct methods instead of qtbot's

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,11 @@ name: build
 
 on: [push, pull_request]
 
+# Cancel running jobs for the same workflow and branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
@@ -12,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         qt-lib: [pyqt5, pyqt6, pyside2, pyside6]
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - python-version: "3.7"
             tox-env: "py37"
@@ -24,20 +29,12 @@ jobs:
             tox-env: "py310"
           - python-version: "3.11"
             tox-env: "py311"
-        # https://bugreports.qt.io/browse/PYSIDE-1797
         exclude:
-          - qt-lib: pyside6
-            os: macos-latest
-            python-version: "3.7"
-          - qt-lib: pyside6
-            os: ubuntu-20.04
-            python-version: "3.7"
-          # Not installable so far
-          - qt-lib: pyside6
-            python-version: "3.11"
-          - qt-lib: pyside2
+          # Not installable:
+          # ERROR: Could not find a version that satisfies the requirement pyside2 (from versions: none)
+          - python-version: "3.11"
+            qt-lib: pyside2
             os: windows-latest
-            python-version: "3.11"
 
     steps:
     - uses: actions/checkout@v3
@@ -50,7 +47,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
-        if [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
+        if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
           sudo apt-get update -y
           sudo apt-get install -y libgles2-mesa-dev
         fi

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -6,8 +6,7 @@ pytest-qt is a `pytest`_ plugin that allows programmers to write tests
 for `PyQt5`_, `PyQt6`_, `PySide2`_ and `PySide6`_ applications.
 
 The main usage is to use the ``qtbot`` fixture, responsible for handling ``qApp``
-creation as needed and provides methods to simulate user interaction,
-like key presses and mouse clicks:
+creation as needed, and registering widgets for testing:
 
 
 .. code-block:: python
@@ -16,8 +15,8 @@ like key presses and mouse clicks:
         widget = HelloWidget()
         qtbot.addWidget(widget)
 
-        # click in the Greet button and make sure it updates the appropriate label
-        qtbot.mouseClick(widget.button_greet, QtCore.Qt.LeftButton)
+        # Click the greet button and make sure the appropriate label is updated.
+        widget.button_greet.click()
 
         assert widget.greet_label.text() == "Hello!"
 

--- a/docs/note_dialogs.rst
+++ b/docs/note_dialogs.rst
@@ -49,12 +49,14 @@ And now it is also easy to mock ``AskNameAndAgeDialog.ask`` when testing the for
 .. code-block:: python
 
     def test_form_registration(qtbot, monkeypatch):
-        form = RegistrationForm()
+        user = User.empty_user()
+        form = RegistrationForm(user)
 
         monkeypatch.setattr(
-            AskNameAndAgeDialog, "ask", classmethod(lambda *args: ("Jonh", 30))
+            AskNameAndAgeDialog, "ask", classmethod(lambda *args: ("John", 30))
         )
-        qtbot.click(form.enter_info())
-        # calls AskNameAndAgeDialog.ask
-        # test that the rest of the form correctly behaves as if
-        # user entered "Jonh" and 30 as name and age
+        # Clicking on the button will call AskNameAndAgeDialog.ask in its slot.
+        form.enter_info_button.click()
+
+        assert user.name == "John"
+        assert user.age == 30

--- a/docs/qapplication.rst
+++ b/docs/qapplication.rst
@@ -26,7 +26,7 @@ For example:
         exit_calls = []
         monkeypatch.setattr(QApplication, "exit", lambda: exit_calls.append(1))
         button = get_app_exit_button()
-        qtbot.click(button)
+        button.click()
         assert exit_calls == [1]
 
 
@@ -37,7 +37,7 @@ Or using the ``mock`` package:
     def test_exit_button(qtbot):
         with mock.patch.object(QApplication, "exit"):
             button = get_app_exit_button()
-            qtbot.click(button)
+            button.click()
             assert QApplication.exit.call_count == 1
 
 

--- a/docs/virtual_methods.rst
+++ b/docs/virtual_methods.rst
@@ -7,13 +7,14 @@ It is common in Qt programming to override virtual C++ methods to customize
 behavior, like listening for mouse events, implement drawing routines, etc.
 
 Fortunately, all Python bindings for Qt support overriding these virtual methods
-naturally in your Python code::
+naturally in your Python code:
+
+.. code-block:: python
 
     class MyWidget(QWidget):
-
         # mouseReleaseEvent
         def mouseReleaseEvent(self, ev):
-            print('mouse released at: %s' % ev.pos())
+            print(f"mouse released at: {ev.pos()}")
 
 In ``PyQt5`` and ``PyQt6``, exceptions in virtual methods will by default call
 abort(), which will crash the interpreter. All other Qt wrappers will print the
@@ -22,12 +23,14 @@ value is required).
 
 This might be surprising for Python users which are used to exceptions
 being raised at the calling point: For example, the following code will just
-print a stack trace without raising any exception::
+print a stack trace without raising any exception:
+
+.. code-block:: python
 
     class MyWidget(QWidget):
-
         def mouseReleaseEvent(self, ev):
-            raise RuntimeError('unexpected error')
+            raise RuntimeError("unexpected error")
+
 
     w = MyWidget()
     QTest.mouseClick(w, QtCore.Qt.LeftButton)
@@ -49,7 +52,9 @@ Disabling the automatic exception hook
 --------------------------------------
 
 You can disable the automatic exception hook on individual tests by using a
-``qt_no_exception_capture`` marker::
+``qt_no_exception_capture`` marker:
+
+.. code-block:: python
 
     @pytest.mark.qt_no_exception_capture
     def test_buttons(qtbot):

--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -55,6 +55,13 @@ class QtBot:
     Those methods are just forwarded directly to the `QTest API`_. Consult the documentation for more
     information.
 
+    .. note::
+        These methods should be rarely be used, in general prefer to interact with widgets
+        using their own methods such as ``QComboBox.setCurrentText``, ``QLineEdit.setText``, etc.
+        Doing so will have the same effect as users interacting with the widget, but are more reliable.
+
+        See :ref:`this note in the tutorial <note-about-qtbot-methods>` for more information.
+
     ---
 
     Below are methods used to simulate sending key events to widgets:


### PR DESCRIPTION
Updates the documentation to use direct methods in most interactions, as the documentation currently leads users to call `qtbot`'s methods for normal interactions, such changing the text of a `QLineEdit` or an item of a `QComboBox`.

Also changed some code examples to use `.. code-block: python`, so they are formatted by black.

In addition, fixed CI, see commit message 1e1a7d589c5d531c82e6257b18ae1732a08674bd.

Closes #488. 
