### PR TITLE
Check if PySide2 supports flag OR-ing for xfail

### DIFF
--- a/tests/test_modeltest.py
+++ b/tests/test_modeltest.py
@@ -113,8 +113,19 @@ def test_broken_types(check_model, broken_role):
     check_model(BrokenTypeModel(), should_pass=False)
 
 
+def check_broken_flag_or():
+    flag = qt_api.QtCore.Qt.AlignmentFlag
+    try:
+        int(flag.AlignHorizontal_Mask | flag.AlignVertical_Mask)
+    except SystemError:
+        # Should not be happening anywhere else
+        assert sys.version_info[:2] == (3, 11) and qt_api.pytest_qt_api == "pyside2"
+        return True
+    return False
+
+
 xfail_py311_pyside2 = pytest.mark.xfail(
-    sys.version_info[:2] == (3, 11) and qt_api.pytest_qt_api == "pyside2",
+    check_broken_flag_or(),
     reason="Fails to OR mask flags",
 )
 


### PR DESCRIPTION
Seems to be fixed somewhere between:

- PySide2 5.15.2.1 (latest version on PyPI)
- PySide2 5.15.10 (version I have installed via Archlinux)

But no idea where exactly, so let's just try it out at import time.

See https://github.com/pytest-dev/pytest-qt/pull/419#discussion_r1240198866