### PR TITLE
qtbot.click() does not exist?

### DIFF
--- a/src/pytestqt/qtbot.py
+++ b/src/pytestqt/qtbot.py
@@ -603,7 +603,9 @@ class QtBot:
         .. code-block:: python
 
             with qtbot.capture_exceptions() as exceptions:
-                qtbot.click(button)
+                qtbot.mouseClick(
+                    button, QtCore.MouseButton.LeftButton  # for PyQt6
+                )  # ... or QtCore.LeftButton in PyQt5
 
             # exception is a list of sys.exc_info tuples
             assert len(exceptions) == 1


### PR DESCRIPTION
As far as I can tell there is no function called `click()` in the `QtBot` class.

Removes the mention of `qtbot.click()` from the documentation, and replaces it with `qtbot.mouseClick()` instead.