### PR TITLE
Pass program name to QApplication contructor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,6 @@ repos:
     -   id: rst
         name: rst
         entry: rst-lint --encoding utf-8
-        files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst)$
+        files: ^(HOWTORELEASE.rst|README.rst)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-4.3.0 (2023-09-20)
-------------------
+UNRELEASED
+-----------
 
 - ``qapp`` now sets up the ``QApplication`` instance with a command line argument like this
   ``QApplication([prog_name])`` instead of using an empty list ``QApplication([])``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,20 @@
+4.3.0 (2023-09-20)
+------------------
+
+- ``qapp`` now sets up the ``QApplication`` instance with a command line argument like this
+  ``QApplication([prog_name])`` instead of using an empty list ``QApplication([])``.
+  Here ``prog_name`` is the name of the app which defaults to ``pytest-qt-app``, but can
+  be redefined in the ``pytest.ini`` file, see :ref:`qapp fixture<setting-qapp-name>`.
+  Alternatively, the arguments that will be passed to ``QApplication`` can be defined
+  explicitly using the ``qapp_args`` fixture. This means that the default behavior of
+  the ``qapp_args`` fixture is now also changed accordingly: it now returns the list
+  ``[prog_name]`` instead of an empty list. Thanks to `@The-Compiler`_ (`#483`_) and
+  `@hakonhagland`_ (`#515`_).
+
+..  _#515: https://github.com/pytest-dev/pytest-qt/pull/515
+..  _#483: https://github.com/pytest-dev/pytest-qt/issues/483
+
+
 4.2.0 (2022-10-25)
 ------------------
 
@@ -731,6 +748,7 @@ First working version.
 .. _@fabioz: https://github.com/fabioz
 .. _@fogo: https://github.com/fogo
 .. _@gqmelo: https://github.com/gqmelo
+.. _@hakonhagland: https://github.com/hakonhagland
 .. _@itghisi: https://github.com/itghisi
 .. _@jdreaver: https://github.com/jdreaver
 .. _@mitya57: https://github.com/mitya57

--- a/docs/qapplication.rst
+++ b/docs/qapplication.rst
@@ -75,6 +75,8 @@ If your tests require access to app-level functions, like
 The ``qapp`` fixture will then use the returned class instead of the default
 ``QApplication`` from ``QtWidgets``.
 
+.. _setting-qapp-name:
+
 Setting a QApplication name
 ---------------------------
 

--- a/src/pytestqt/plugin.py
+++ b/src/pytestqt/plugin.py
@@ -12,7 +12,7 @@ from pytestqt.qtbot import QtBot, _close_widgets
 
 
 @pytest.fixture(scope="session")
-def qapp_args():
+def qapp_args(pytestconfig):
     """
     Fixture that provides QApplication arguments to use.
 
@@ -23,9 +23,19 @@ def qapp_args():
 
        @pytest.fixture(scope="session")
        def qapp_args():
-           return ["--arg"]
+           return ["prog_name", "--arg=foo"]
+
+
+    Note that it can only be overridden once at session scope.
+    It is not possible to override this per unit test since a QApplication
+    cannot be destroyed and recreated within the same app.
+
+    The default value is a list with one element which is determined the same
+    way as for ``QApplication.applicationName()``,
+    see :ref:`qapp fixture<setting-qapp-name>` for more information.
+
     """
-    return []
+    return [pytestconfig.getini("qt_qapp_name")]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -546,13 +546,35 @@ def test_qapp_args(testdir):
 
         @pytest.fixture(scope='session')
         def qapp_args():
-            return ['--test-arg']
+            return ['prog_name', '--test-arg']
         """
     )
     testdir.makepyfile(
         """
         def test_args(qapp):
             assert '--test-arg' in list(qapp.arguments())
+    """
+    )
+    result = testdir.runpytest_subprocess()
+    result.stdout.fnmatch_lines(["*= 1 passed in *"])
+
+
+def test_qapp_args_default(testdir):
+    """
+    Test QApplication default arguments.
+    """
+
+    #    testdir.makeini(
+    #        """
+    #        [pytest]
+    #        qt_qapp_name = frobnicator
+    #        """
+    #    )
+    testdir.makepyfile(
+        """
+        def test_args(qapp):
+            args = qapp.arguments()
+            assert args[0] == 'pytest-qt-qapp'
     """
     )
     result = testdir.runpytest_subprocess()

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -564,12 +564,6 @@ def test_qapp_args_default(testdir):
     Test QApplication default arguments.
     """
 
-    #    testdir.makeini(
-    #        """
-    #        [pytest]
-    #        qt_qapp_name = frobnicator
-    #        """
-    #    )
     testdir.makepyfile(
         """
         def test_args(qapp):

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -617,7 +617,7 @@ class TestCallback:
     @staticmethod
     def get_signal_from_code(signaller, code):
         """Converts a code such as 'A1' to a signal (signaller.signal_args for example)."""
-        assert type(code) == str and len(code) == 2
+        assert type(code) is str and len(code) == 2
         signal = signaller.signal_args if code[0] == "A" else signaller.signal_args_2
         return signal
 


### PR DESCRIPTION
`QCommandLineParser` needs `QApplication` to be initialized with a list with at least one argument: The name of the program.

See https://github.com/pytest-dev/pytest-qt/issues/514#issuecomment-1696462533 for an example.

Closes #483.