### PR TITLE
Set sphinx module path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../src"))
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
Sphinx module path should be set to `../src` not `..` for sphinx autodoc extension to work locally when typing `make html` from the `docs` folder. If not, `sphinx-build` might use a source file from pytest-qt installed in the python `site-packages` directory outside the git repo which is obviously not correct (and very frustrating to debug :) )