### PR TITLE
Fix test_exceptions_dont_leak in Python 3.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+UNRELEASED
+----------
+
+- Fixed exception handling so they are properly cleared in Python 3.12, due to the new `sys.last_exc <https://docs.python.org/3/library/sys.html#sys.last_exc>`__ attribute (`#532`_).
+
+..  _#532: https://github.com/pytest-dev/pytest-qt/issues/532
+
 4.3.1 (2023-12-22)
 ------------------
 

--- a/src/pytestqt/exceptions.py
+++ b/src/pytestqt/exceptions.py
@@ -65,6 +65,8 @@ class _QtExceptionCaptureManager:
             prefix = "%s ERROR: " % when
             msg = prefix + format_captured_exceptions(exceptions)
             del exceptions[:]  # Don't keep exceptions alive longer.
+            if hasattr(sys, "last_exc"):
+                sys.last_exc = None
             pytest.fail(msg, pytrace=False)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -365,9 +365,6 @@ def test_exceptions_to_stderr(qapp, capsys):
 
 
 @exception_capture_pyside6
-@pytest.mark.skipif(
-    sys.version_info[:2] == (3, 12), reason="#532 requires investigation"
-)
 def test_exceptions_dont_leak(testdir):
     """
     Ensure exceptions are cleared when an exception occurs and don't leak (#187).


### PR DESCRIPTION
I wonder if clearing it is the right call, after all the purpose of `sys.last_exc` is for post-mortem debugging -- however I'm not sure that at that point is possible to breakpoint at that point.

Fixes #532