### PR TITLE
Use new-style hook wrappers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+- ``pluggy >=1.1`` is now required: we now use new-style hook wrappers, which are less error prone.
+
 - Fixed exception handling so they are properly cleared in Python 3.12, due to the new `sys.last_exc <https://docs.python.org/3/library/sys.html#sys.last_exc>`__ attribute (`#532`_).
 
 ..  _#532: https://github.com/pytest-dev/pytest-qt/issues/532

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     entry_points={"pytest11": ["pytest-qt = pytestqt.plugin"]},
-    install_requires=["pytest>=3.0.0"],
+    install_requires=["pytest>=3.0.0", "pluggy>=1.1"],
     extras_require={
         "doc": ["sphinx", "sphinx_rtd_theme"],
         "dev": ["pre-commit", "tox"],

--- a/src/pytestqt/logging.py
+++ b/src/pytestqt/logging.py
@@ -39,16 +39,14 @@ class QtLoggingPlugin:
         item.qt_log_capture = _QtMessageCapture(ignore_regexes)
         item.qt_log_capture._start()
 
-    @pytest.hookimpl(hookwrapper=True)
+    @pytest.hookimpl(wrapper=True)
     def pytest_runtest_makereport(self, item, call):
         """Add captured Qt messages to test item report if the call failed."""
-        outcome = yield
+        report = yield
         if not hasattr(item, "qt_log_capture"):
-            return
+            return report
 
         if call.when == "call":
-            report = outcome.get_result()
-
             m = get_marker(item, "qt_log_level_fail")
             if m:
                 log_fail_level = m.args[0]
@@ -111,6 +109,7 @@ class QtLoggingPlugin:
 
             item.qt_log_capture._stop()
             del item.qt_log_capture
+        return report
 
 
 class _QtMessageCapture:


### PR DESCRIPTION
The [new-style hook wrappers](https://pluggy.readthedocs.io/en/stable/#wrappers) are easier to use because you do not need to call `outcome.force_exception` on errors, and doing so prevents other hook callers from running.

This requires pluggy>=1.1.