### PR TITLE
Release 4.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
-UNRELEASED
-----------
+4.4.0 (2024-02-07)
+------------------
 
 - ``pluggy >=1.1`` is now required: we now use new-style hook wrappers, which are less error prone.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     entry_points={"pytest11": ["pytest-qt = pytestqt.plugin"]},
-    install_requires=["pytest>=3.0.0", "pluggy>=1.1"],
+    install_requires=["pytest", "pluggy>=1.1"],
     extras_require={
         "doc": ["sphinx", "sphinx_rtd_theme"],
         "dev": ["pre-commit", "tox"],


### PR DESCRIPTION
Simplify the pytest requirement because due to our own python requirement (3.8+), the pytest requirement is met.