### PR TITLE
Add Azure Pipelines instructions for running pytest-qt tests with PyQt6 to documentation

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -127,15 +127,25 @@ And here is a working Qt6 Azure Pipelines CI/CD config for ``ubuntu-latest`` :
 
 .. code-block:: yaml
 
-    # this was tested with ``ubuntu-latest`` image
-    - script: |
-        sudo apt update
-        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
-        sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
-        sudo apt-get install -y x11-utils
-        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
-      displayName: 'Install and start xvfb and other dependencies on Linux for Qt GUI tests'
-      condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+    # Set these environment variables for the job that runs tests
+
+    variables:
+      DISPLAY: ':99.0'  # This is needed for pytest-qt not to crash as mentioned above
+      # Python fault handler is enabled in case UI tests crash without meaningful error messages
+      PYTHONFAULTHANDLER: 'enabled'  # https://docs.python.org/3/library/faulthandler.html
+
+    # Add this step to your CI pipeline before running your pytest-qt-based Qt6 tests with pytest
+
+        # this was tested with ``ubuntu-latest`` image
+        - script: |
+            sudo apt update
+            sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
+            sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+            sudo apt-get install -y x11-utils
+            /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+          displayName: 'Install and start xvfb and other dependencies on Linux for Qt GUI tests'
+          condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+
     # After this step, assuming you have ``pytest-qt`` installed, just run ``pytest`` and your PyQt6 tests will work
 
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -123,6 +123,22 @@ And here is a working Qt6 GitLab CI/CD config :
         - python -m pytest test.py
 
 
+And here is a working Qt6 Azure Pipelines CI/CD config for ``ubuntu-latest`` :
+
+.. code-block:: yaml
+
+    # this was tested with ``ubuntu-latest`` image
+    - script: |
+        sudo apt update
+        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
+        sudo apt-get install -y '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+        sudo apt-get install -y x11-utils
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+      displayName: 'Install and start xvfb and other dependencies on Linux for Qt GUI tests'
+      condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+    # After this step, assuming you have ``pytest-qt`` installed, just run ``pytest`` and your PyQt6 tests will work
+
+
 ``tlambert03/setup-qt-libs``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Instead manually curate list of used packages you may use ``tlambert03/setup-qt-libs`` github action: https://github.com/tlambert03/setup-qt-libs


### PR DESCRIPTION
I hope this will be helpful for folks!

without this i've been seeing this fatal error (with python fault handler enabled):
```
tests/test_gui.py Fatal Python error: Aborted

Current thread 0x00007fde441e9c40 (most recent call first):

  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 126 in runtestprotocol
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 113 in pytest_runtest_protocol
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/main.py", line 362 in pytest_runtestloop
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/main.py", line 337 in _main
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/main.py", line 283 in wrap_session
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/main.py", line 330 in pytest_cmdline_main
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 175 in main
  File "/home/vsts/work/1/s/.venv/lib/python3.11/site-packages/_pytest/config/__init__.py", line 201 in console_main
  File "/home/vsts/work/1/s/.venv/bin/pytest", line 10 in <module>

Extension modules: PyQt6.QtCore, PyQt6.QtGui, PyQt6.QtWidgets, PyQt6.QtTest, psutil._psutil_linux, psutil._psutil_posix, numpy._core._multiarray_umath, numpy.linalg._umath_linalg, charset_normalizer.md, requests.packages.charset_normalizer.md, requests.packages.chardet.md (total: 11)

##[error]Bash exited with code '134'.
```