### PR TITLE
Enable qInfo tests for PySide6

### DIFF
--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -111,14 +111,7 @@ class _QtApi:
 
         self._check_qt_api_version()
 
-        # qInfo is not exposed in PySide6 (#232)
-        if hasattr(QtCore, "QMessageLogger"):
-            self.qInfo = lambda msg: QtCore.QMessageLogger().info(msg)
-        elif hasattr(QtCore, "qInfo"):
-            self.qInfo = QtCore.qInfo
-        else:
-            self.qInfo = None
-
+        self.qInfo = QtCore.qInfo
         self.qDebug = QtCore.qDebug
         self.qWarning = QtCore.qWarning
         self.qCritical = QtCore.qCritical

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -613,6 +613,7 @@ def test_already_loaded_backend(monkeypatch, option_api, backend):
     qtcore = Mock()
     for method_name in (
         "qInstallMessageHandler",
+        "qInfo",
         "qDebug",
         "qWarning",
         "qCritical",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,8 +26,7 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
         qt_api.QtCore.qInstallMessageHandler(print_msg)
 
         def test_types():
-            # qInfo is not exposed by the bindings yet (#225)
-            # qt_api.qInfo('this is an INFO message')
+            qt_api.qInfo('this is an INFO message')
             qt_api.qDebug('this is a DEBUG message')
             qt_api.qWarning('this is a WARNING message')
             qt_api.qCritical('this is a CRITICAL message')
@@ -45,8 +44,7 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
             res.stdout.fnmatch_lines(
                 [
                     "*-- Captured Qt messages --*",
-                    # qInfo is not exposed by the bindings yet (#232)
-                    # '*QtInfoMsg: this is an INFO message*',
+                    "*QtInfoMsg: this is an INFO message*",
                     "*QtDebugMsg: this is a DEBUG message*",
                     "*QtWarningMsg: this is a WARNING message*",
                     "*QtCriticalMsg: this is a CRITICAL message*",
@@ -56,9 +54,7 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
             res.stdout.fnmatch_lines(
                 [
                     "*-- Captured stderr call --*",
-                    # qInfo is not exposed by the bindings yet (#232)
-                    # '*QtInfoMsg: this is an INFO message*',
-                    # 'this is an INFO message*',
+                    "this is an INFO message*",
                     "this is a DEBUG message*",
                     "this is a WARNING message*",
                     "this is a CRITICAL message*",
@@ -66,33 +62,17 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
             )
 
 
-def test_qinfo(qtlog):
-    """Test INFO messages when we have means to do so. Should be temporary until bindings
-    catch up and expose qInfo (or at least QMessageLogger), then we should update
-    the other logging tests properly. #232
-    """
-
-    if qt_api.is_pyside:
-        assert (
-            qt_api.qInfo is None
-        ), "pyside6 does not expose qInfo. If it does, update this test."
-        return
-
-    qt_api.qInfo("this is an INFO message")
-    records = [(m.type, m.message.strip()) for m in qtlog.records]
-    assert records == [(qt_api.QtCore.QtMsgType.QtInfoMsg, "this is an INFO message")]
-
-
 def test_qtlog_fixture(qtlog):
     """
     Test qtlog fixture.
     """
-    # qInfo is not exposed by the bindings yet (#232)
+    qt_api.qInfo("this is an INFO message")
     qt_api.qDebug("this is a DEBUG message")
     qt_api.qWarning("this is a WARNING message")
     qt_api.qCritical("this is a CRITICAL message")
     records = [(m.type, m.message.strip()) for m in qtlog.records]
     assert records == [
+        (qt_api.QtCore.QtMsgType.QtInfoMsg, "this is an INFO message"),
         (qt_api.QtCore.QtMsgType.QtDebugMsg, "this is a DEBUG message"),
         (qt_api.QtCore.QtMsgType.QtWarningMsg, "this is a WARNING message"),
         (qt_api.QtCore.QtMsgType.QtCriticalMsg, "this is a CRITICAL message"),


### PR DESCRIPTION
PySide6 now exposes `qInfo` just like Qt6. This enables the `qInfo`
tests accordingly.

For reference see issue #232.
