### PR TITLE
Test and restore compatibility with older PySide/PyQt versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,13 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         qt-lib: [pyqt5, pyqt6, pyside6]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - python-version: "3.9"
+            qt-lib: pyqt61
+            os: ubuntu-latest
+          - python-version: "3.9"
+            qt-lib: pyside60
+            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -24,7 +24,7 @@ QT_APIS["pyqt5"] = "PyQt5"
 
 
 def _import(name):
-    """Think call so we can mock it during testing"""
+    """Thin call so we can mock it during testing"""
     return __import__(name)
 
 
@@ -112,10 +112,10 @@ class _QtApi:
         self._check_qt_api_version()
 
         # qInfo is not exposed in PySide6 < 6.8.2 (#232)
-        if hasattr(QtCore, "QMessageLogger"):
-            self.qInfo = lambda msg: QtCore.QMessageLogger().info(msg)
-        elif hasattr(QtCore, "qInfo"):
+        if hasattr(QtCore, "qInfo"):
             self.qInfo = QtCore.qInfo
+        elif hasattr(QtCore, "QMessageLogger"):
+            self.qInfo = lambda msg: QtCore.QMessageLogger().info(msg)
         else:
             self.qInfo = None
 

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -111,7 +111,7 @@ class _QtApi:
 
         self._check_qt_api_version()
 
-        # qInfo is not exposed in PySide6 (#232)
+        # qInfo is not exposed in PySide6 < 6.8.2 (#232)
         if hasattr(QtCore, "QMessageLogger"):
             self.qInfo = lambda msg: QtCore.QMessageLogger().info(msg)
         elif hasattr(QtCore, "qInfo"):

--- a/src/pytestqt/qt_compat.py
+++ b/src/pytestqt/qt_compat.py
@@ -111,7 +111,14 @@ class _QtApi:
 
         self._check_qt_api_version()
 
-        self.qInfo = QtCore.qInfo
+        # qInfo is not exposed in PySide6 (#232)
+        if hasattr(QtCore, "QMessageLogger"):
+            self.qInfo = lambda msg: QtCore.QMessageLogger().info(msg)
+        elif hasattr(QtCore, "qInfo"):
+            self.qInfo = QtCore.qInfo
+        else:
+            self.qInfo = None
+
         self.qDebug = QtCore.qDebug
         self.qWarning = QtCore.qWarning
         self.qCritical = QtCore.qCritical

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -613,7 +613,6 @@ def test_already_loaded_backend(monkeypatch, option_api, backend):
     qtcore = Mock()
     for method_name in (
         "qInstallMessageHandler",
-        "qInfo",
         "qDebug",
         "qWarning",
         "qCritical",

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -309,20 +309,13 @@ def test_event_processing_before_and_after_teardown(testdir):
     res.stdout.fnmatch_lines(["*3 passed in*"])
 
 
-def test_header(testdir):
-    testdir.makeconftest(
-        """
-        from pytestqt import qt_compat
-        from pytestqt.qt_compat import qt_api
-
-        def mock_get_versions():
-            return qt_compat.VersionTuple('PyQtAPI', '1.0', '2.5', '3.5')
-
-        assert hasattr(qt_api, 'get_versions')
-        qt_api.get_versions = mock_get_versions
-        """
+def test_header(testdir, monkeypatch):
+    monkeypatch.setattr(
+        qt_api,
+        "get_versions",
+        lambda: qt_compat.VersionTuple("PyQtAPI", "1.0", "2.5", "3.5"),
     )
-    res = testdir.runpytest()
+    res = testdir.runpytest_inprocess()
     res.stdout.fnmatch_lines(
         ["*test session starts*", "PyQtAPI 1.0 -- Qt runtime 2.5 -- Qt compiled 3.5"]
     )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,11 +5,18 @@ import pytest
 from pytestqt.exceptions import capture_exceptions, format_captured_exceptions
 from pytestqt.qt_compat import qt_api
 
+
+def has_pyside6_exception_capture():
+    return qt_api.pytest_qt_api == "pyside6" and tuple(
+        int(part) for part in qt_api.get_versions().qt_api_version.split(".")
+    ) >= (6, 5, 2)
+
+
 # PySide6 is automatically captures exceptions during the event loop,
 # and re-raises them when control gets back to Python, so the related
 # functionality does not work, nor is needed for the end user.
 exception_capture_pyside6 = pytest.mark.skipif(
-    qt_api.pytest_qt_api == "pyside6",
+    has_pyside6_exception_capture(),
     reason="pytest-qt capture not working/needed on PySide6",
 )
 
@@ -51,7 +58,7 @@ def test_catch_exceptions_in_virtual_methods(testdir, raise_error):
     )
     result = testdir.runpytest()
     if raise_error:
-        if qt_api.pytest_qt_api == "pyside6":
+        if has_pyside6_exception_capture():
             # PySide6 automatically captures exceptions during the event loop,
             # and re-raises them when control gets back to Python.
             # This results in the exception not being captured by

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,7 +26,8 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
         qt_api.QtCore.qInstallMessageHandler(print_msg)
 
         def test_types():
-            qt_api.qInfo('this is an INFO message')
+            # qInfo is not exposed by the bindings yet (#225)
+            # qt_api.qInfo('this is an INFO message')
             qt_api.qDebug('this is a DEBUG message')
             qt_api.qWarning('this is a WARNING message')
             qt_api.qCritical('this is a CRITICAL message')
@@ -44,7 +45,8 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
             res.stdout.fnmatch_lines(
                 [
                     "*-- Captured Qt messages --*",
-                    "*QtInfoMsg: this is an INFO message*",
+                    # qInfo is not exposed by the bindings yet (#232)
+                    # '*QtInfoMsg: this is an INFO message*',
                     "*QtDebugMsg: this is a DEBUG message*",
                     "*QtWarningMsg: this is a WARNING message*",
                     "*QtCriticalMsg: this is a CRITICAL message*",
@@ -54,7 +56,9 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
             res.stdout.fnmatch_lines(
                 [
                     "*-- Captured stderr call --*",
-                    "this is an INFO message*",
+                    # qInfo is not exposed by the bindings yet (#232)
+                    # '*QtInfoMsg: this is an INFO message*',
+                    # 'this is an INFO message*',
                     "this is a DEBUG message*",
                     "this is a WARNING message*",
                     "this is a CRITICAL message*",
@@ -62,17 +66,33 @@ def test_basic_logging(testdir, test_succeeds, qt_log):
             )
 
 
+def test_qinfo(qtlog):
+    """Test INFO messages when we have means to do so. Should be temporary until bindings
+    catch up and expose qInfo (or at least QMessageLogger), then we should update
+    the other logging tests properly. #232
+    """
+
+    if qt_api.is_pyside:
+        assert (
+            qt_api.qInfo is None
+        ), "pyside6 does not expose qInfo. If it does, update this test."
+        return
+
+    qt_api.qInfo("this is an INFO message")
+    records = [(m.type, m.message.strip()) for m in qtlog.records]
+    assert records == [(qt_api.QtCore.QtMsgType.QtInfoMsg, "this is an INFO message")]
+
+
 def test_qtlog_fixture(qtlog):
     """
     Test qtlog fixture.
     """
-    qt_api.qInfo("this is an INFO message")
+    # qInfo is not exposed by the bindings yet (#232)
     qt_api.qDebug("this is a DEBUG message")
     qt_api.qWarning("this is a WARNING message")
     qt_api.qCritical("this is a CRITICAL message")
     records = [(m.type, m.message.strip()) for m in qtlog.records]
     assert records == [
-        (qt_api.QtCore.QtMsgType.QtInfoMsg, "this is an INFO message"),
         (qt_api.QtCore.QtMsgType.QtDebugMsg, "this is a DEBUG message"),
         (qt_api.QtCore.QtMsgType.QtWarningMsg, "this is a WARNING message"),
         (qt_api.QtCore.QtMsgType.QtCriticalMsg, "this is a CRITICAL message"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,15 @@
 [tox]
-envlist = py{39,310,311,312,313}-{pyqt5,pyside6,pyqt6}
+envlist = py{39,310,311,312,313}-{pyqt5,pyside6,pyqt6},py39-pyside60,py39-pyqt61
 
 [testenv]
 deps=
     pytest
     pyside6: pyside6
+    pyside60: pyside6<6.1
     pyqt5: pyqt5
     pyqt6: pyqt6
+    pyqt61: pyqt6<6.2
+    pyqt61: pyqt6-sip<13.6
 commands=
     pytest --color=yes {posargs}
 setenv=


### PR DESCRIPTION
This PR:

- Reverts #593, and thus restores compatibility with PySide6 < 6.8.2, as we want to support older versions as well
- Instead makes sure that the tests run in both scenarios properly (whether `qInfo` is present or not)
- Makes sure we use the real `qInfo` (and not our `QMessageLogger` shim) if present
- Fixes exception capture tests with more fine-grained Qt backend version checks so that they also run with older PySide versions
- Actually runs the tests on CI for PyQt6 6.1 and PySide6 6.0 (both of which we claim to support according to the checks in `qt_compat.py`) to avoid future regressions
- Fixes an issue in the testsuite which leaked global patching and broke those checks

Probably best reviewed commit by commit (and not squash-merged).