### PR TITLE
Cleanup timer in signal blocker from the correct thread

### DIFF
--- a/src/pytestqt/wait_signal.py
+++ b/src/pytestqt/wait_signal.py
@@ -69,7 +69,17 @@ class _AbstractSignalBlocker:
     def _cleanup(self):
         # store timeout message before the data to construct it is lost
         self._timeout_message = self._get_timeout_error_message()
-        self._timer.stop()
+
+        timer_meta = self._timer.metaObject()
+        timer_stop_signature = (
+            timer_meta.normalizedSignature("stop").data().decode("utf-8")
+        )
+        timer_stop_method = timer_meta.method(
+            timer_meta.indexOfMethod(timer_stop_signature)
+        )
+        timer_stop_method.invoke(
+            self._timer, qt_api.QtCore.Qt.ConnectionType.QueuedConnection
+        )
 
     def _get_timeout_error_message(self):
         """Subclasses have to implement this, returning an appropriate error message for a TimeoutError."""

--- a/tests/test_wait_signal.py
+++ b/tests/test_wait_signal.py
@@ -1425,15 +1425,6 @@ def test_signal_raised_from_thread(
     res = pytester.runpytest_subprocess("-x", "-s")
     outcomes = res.parseoutcomes()
 
-    if outcomes.get("failed", 0) and check_stderr and qt_api.pytest_qt_api == "pyside6":
-        # The test succeeds on PyQt (unsure why!), but we can't check
-        # qt_api.pytest_qt_api at import time, so we can't use
-        # pytest.mark.xfail conditionally.
-        pytest.xfail(
-            "Qt error: QObject::killTimer: "
-            "Timers cannot be stopped from another thread"
-        )
-
     res.assert_outcomes(passed=outcomes["passed"])  # no failed/error
 
 


### PR DESCRIPTION
According to the [PySide6 documentation on QTimer](https://doc.qt.io/qtforpython-6/PySide6/QtCore/QTimer.html#detailed-description):

> Qt uses the timer’s thread affinity to determine which thread will emit the timeout() signal.
Because of this, you must start and stop the timer in its thread;

Because of that, we need to schedule the stop invokation to run in the timer's parent thread. This ensures correct behavior when handling signals emitted from different threads.